### PR TITLE
Generate catalogue manifest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,18 +18,22 @@ set +x
 
 # Expected env variables:
 # * [GCE_ACCOUNT] - credentials for the google service account (JSON blob)
+# * [TILE_HOST] - "tiles.maps.elastic.co" or "tiles-maps-stage.elastic.co" (default)
 # * [VECTOR_HOST] - "vector.maps.elastic.co" or "vector-staging.maps.elastic.co" (default)
+# * [CATALOGUE_BUCKET] - "elastic-ems-prod-files-catalogue" or "elastic-ems-prod-files-catalogue-staging"
 # * [VECTOR_BUCKET] - "elastic-ems-prod-files-vector" or "elastic-ems-prod-files-vector-staging".
-#                     If VECTOR_BUCKET is not set, the files are built locally but not uploaded.
-# * [ARCHIVE_BUCKET] - "elastic-ems-prod-files-vector-archive"
+#                     If VECTOR_BUCKET or CATALOGUE_BUCKET is not set, the files are built locally but not uploaded.
+# * [ARCHIVE_BUCKET] - "elastic-ems-prod-files-archive"
 #                      If ARCHIVE_BUCKET is set, a timestamped snapshot of the files is uploaded to the bucket.
 
 if [[ -z "${VECTOR_HOST}" ]]; then
-    echo "VECTOR_HOST is not set. Defaulting to 'vector-staging.maps.elastic.co'."
+    VECTOR_HOST="vector-staging.maps.elastic.co"
+    echo "VECTOR_HOST is not set. Defaulting to '${VECTOR_HOST}'."
 fi
 
 if [[ -z "${TILE_HOST}" ]]; then
-    echo "TILE_HOST is not set. Defaulting to 'tiles-maps-stage.elastic.co'"
+    TILE_HOST="tiles-maps-stage.elastic.co"
+    echo "TILE_HOST is not set. Defaulting to '${TILE_HOST}'."
 fi
 
 if [[ "$1" != "nodocker" ]]; then
@@ -71,7 +75,13 @@ if [[ "$1" != "nodocker" ]]; then
             /app/build.sh nodocker "$@"
         unset GCE_ACCOUNT
     else
-        echo "VECTOR_BUCKET or CATALOGUE_BUCKET is not set. No data will be uploaded."
+        echo "No data will be uploaded. The following bucket information is not set:"
+        if [[ -z "${VECTOR_BUCKET}" ]]; then
+          echo "VECTOR_BUCKET"
+        fi
+        if [[ -z "${CATALOGUE_BUCKET}" ]]; then
+          echo "CATALOGUE_BUCKET"
+        fi
     fi
 
 else

--- a/deployProduction.sh
+++ b/deployProduction.sh
@@ -18,10 +18,12 @@ if [[ -z "${GPROJECT}" ]]; then
     exit 1
 fi
 
-export EMS_PROJECT="files-vector"
+export EMS_PROJECT="files"
 
-export TARGET_HOST="vector.maps.elastic.co"
-export TARGET_BUCKET=${GPROJECT}-${EMS_PROJECT}
+export TILE_HOST="tiles.maps.elastic.co"
+export VECTOR_HOST="vector.maps.elastic.co"
+export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue
+export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector
 export ARCHIVE_BUCKET=${GPROJECT}-files-archive
 
 ./build.sh

--- a/deployStaging.sh
+++ b/deployStaging.sh
@@ -20,8 +20,10 @@ fi
 
 export EMS_PROJECT="files"
 
-export TARGET_HOST="staging-dot-elastic-layer.appspot.com"
-export TARGET_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector-staging
+export TILE_HOST="tiles-maps-stage.elastic.co"
+export VECTOR_HOST="vector-staging.maps.elastic.co"
+export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue-staging
+export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector-staging
 
 unset ARCHIVE_BUCKET
 

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -5,7 +5,9 @@
  */
 
 module.exports = Object.freeze({
-  PRODUCTION_HOST: 'vector.maps.elastic.co',
-  STAGING_HOST: 'staging-dot-elastic-layer.appspot.com',
+  VECTOR_PRODUCTION_HOST: 'vector.maps.elastic.co',
+  VECTOR_STAGING_HOST: 'vector-staging.maps.elastic.co',
+  TILE_PRODUCTION_HOST: 'tiles.maps.elastic.co',
+  TILE_STAGING_HOST: 'tiles-maps-stage.elastic.co',
   VERSIONS: ['v1', 'v2'],
 });

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -8,21 +8,57 @@ const semver = require('semver');
 const _ = require('lodash');
 const constants = require('./constants');
 
-module.exports = generateManifest;
+module.exports = {
+  generateVectorManifest,
+  generateCatalogueManifest,
+};
 
 /**
- * Generate a manifest for a specific version
+ * Generate a catalogue manifest for a specific version of Elastic Maps Service
+ * @param {Object} [opts]
+ * @param {string} [opts.version='v0'] - Version of vector file manifest to link to
+ * @param {string} [opts.tileHostname=`${constants.TILE_STAGING_HOST}`] - Hostname for tile manifest
+ * @param {string} [opts.vectorHostname=`${constants.VECTOR_STAGING_HOST}`] - Hostname for files manifest
+ */
+function generateCatalogueManifest(opts) {
+  opts = {
+    version: 'v0',
+    tileHostname: constants.TILE_STAGING_HOST,
+    vectorHostname: constants.VECTOR_STAGING_HOST,
+    ...opts,
+  };
+  if (!semver.valid(semver.coerce(opts.version))) {
+    throw new Error('A valid version parameter must be defined');
+  }
+  const manifest = {
+    services: [{
+      id: 'tiles_v2',
+      name: 'Elastic Maps Tile Service',
+      manifest: `https://${opts.tileHostname}/v2/manifest`,
+      type: 'tms',
+    }, {
+      id: 'geo_layers',
+      name: 'Elastic Maps Vector Service',
+      manifest: `https://${opts.vectorHostname}/${opts.version}/manifest`,
+      type: 'file',
+    }],
+  };
+  return manifest;
+}
+
+/**
+ * Generate a vector manifest for a specific version
  * @param {Object[]} sources - An array of layer objects
  * @param {Object} [opts]
  * @param {string} [opts.version='0'] - Only include layers that satisfy this semver version
  * @param {boolean} [opts.production=false] - If true, include only production layers
- * @param {string} [opts.hostname=`${constants.STAGING_HOST}`] - Hostname for files in manifest
+ * @param {string} [opts.hostname=`${constants.VECTOR_STAGING_HOST}`] - Hostname for files in manifest
  */
-function generateManifest(sources, opts) {
+function generateVectorManifest(sources, opts) {
   opts = {
     version: 'v0',
     production: false,
-    hostname: constants.STAGING_HOST, ...opts,
+    hostname: constants.VECTOR_STAGING_HOST, ...opts,
   };
   if (!semver.valid(semver.coerce(opts.version))) {
     throw new Error('A valid version parameter must be defined');


### PR DESCRIPTION
This adds code to generate and deploy the catalogue manifest.

Adding the catalogue manifest to the deployment scripts might not be necessary at this time since it's a very static file. I'm on the fence about that. Would appreciate input from the team.