### PR TITLE
[chore] Fix OpenStreetMap attribution link

### DIFF
--- a/sources/au/states.hjson
+++ b/sources/au/states.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  States of Australia
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2

--- a/sources/ca/provinces.hjson
+++ b/sources/ca/provinces.hjson
@@ -4,7 +4,7 @@
     type: http
     note: Canadian provinces
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2

--- a/sources/ch/switzerland-cantons.hjson
+++ b/sources/ch/switzerland-cantons.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  Cantons of Switzerland
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2

--- a/sources/de/states.hjson
+++ b/sources/de/states.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  States of Germany
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2

--- a/sources/fr/departments.hjson
+++ b/sources/fr/departments.hjson
@@ -4,7 +4,7 @@
     type: http
     note: Administrative departments of France
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2

--- a/sources/ie/ireland-counties.hjson
+++ b/sources/ie/ireland-counties.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  Counties and Provinces of Ireland
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2

--- a/sources/jp/prefectures.hjson
+++ b/sources/jp/prefectures.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  Prefectures of Japan
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2

--- a/sources/us/counties.hjson
+++ b/sources/us/counties.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  Counties of United States
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: fips_6_4

--- a/sources/us/states.hjson
+++ b/sources/us/states.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  States of United States
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: postal

--- a/sources/zh/provinces.hjson
+++ b/sources/zh/provinces.hjson
@@ -4,7 +4,7 @@
     type: http
     note:  Administrative divisions of China
     data: https://sophox.org/regions/geojson.json
-    attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
+    attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
             name: iso_3166_2


### PR DESCRIPTION
The OpenStreetMap attribution link should match how it's done in the tiles manifest to avoid duplicate attributions in Kibana region maps. The duplicate EMS attributions should be fixed by resolving the issue in https://github.com/elastic/kibana/pull/22003#issuecomment-414770867. 
<img width="621" alt="screen shot 2018-08-21 at 11 22 41 am" src="https://user-images.githubusercontent.com/1638483/44421172-a7fc1c80-a534-11e8-9c19-b9e105fbc09c.png">
