### PR TITLE
Use URL `{hostname}/blob/{id}` when `id` exists otherwise `{hostname}/files/{filename}`

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -101,11 +101,12 @@ function throwIfDuplicates(array, prop) {
 
 function manifestLayerV1(data, hostname) {
   const manifestId = data.id || data.filename;
+  const urlPath = data.id ? `blob/${data.id}` : `files/${data.filename}`;
   const layer = {
     attribution: data.attribution,
     weight: data.weight,
     name: data.humanReadableName,
-    url: `https://${hostname}/files/${data.filename}?elastic_tile_service_tos=agree`,
+    url: `https://${hostname}/${urlPath}?elastic_tile_service_tos=agree`,
     format: data.conform.type,
     fields: data.fieldMapping.map(fieldMap => ({
       name: fieldMap.dest,

--- a/test/fixtures/sources.json
+++ b/test/fixtures/sources.json
@@ -72,6 +72,29 @@
   },
   {
     "versions": ">=2",
+    "production": true,
+    "attribution": "Similarion",
+    "type": "http",
+    "data": "http://example.com",
+    "name": "Rohan",
+    "humanReadableName": "Rohan Kingdoms",
+    "fieldMapping": [
+      {
+        "name": "label_en",
+        "source": "label_en",
+        "dest": "label_en",
+        "desc": "Kingdom name (English)"
+      }
+    ],
+    "weight": 0,
+    "conform": {
+      "type": "topojson"
+    },
+    "createdAt": "1200-02-28T17:13:39.456456",
+    "filename": "rohan_v2.json"
+  },
+  {
+    "versions": ">=2",
     "production": false,
     "attribution": "Similarion",
     "type": "http",

--- a/test/generate-manifest.js
+++ b/test/generate-manifest.js
@@ -16,7 +16,7 @@ const v1Expected = {
     'attribution': 'Similarion',
     'weight': 0,
     'name': 'Gondor Kingdoms',
-    'url': `https://staging-dot-elastic-layer.appspot.com/files/gondor_v2.json?elastic_tile_service_tos=agree`,
+    'url': `https://staging-dot-elastic-layer.appspot.com/blob/222222222222?elastic_tile_service_tos=agree`,
     'format': 'geojson',
     'fields': [{
       'name': 'label_en',
@@ -29,7 +29,7 @@ const v1Expected = {
     'attribution': 'Similarion',
     'weight': 0,
     'name': 'Mordor Regions',
-    'url': `https://staging-dot-elastic-layer.appspot.com/files/mordor_v1.json?elastic_tile_service_tos=agree`,
+    'url': `https://staging-dot-elastic-layer.appspot.com/blob/111111111111?elastic_tile_service_tos=agree`,
     'format': 'geojson',
     'fields': [
       {
@@ -49,7 +49,7 @@ const v2Expected = {
       'attribution': 'Similarion',
       'weight': 0,
       'name': 'Gondor Kingdoms',
-      'url': `https://staging-dot-elastic-layer.appspot.com/files/gondor_v2.json?elastic_tile_service_tos=agree`,
+      'url': `https://staging-dot-elastic-layer.appspot.com/blob/222222222222?elastic_tile_service_tos=agree`,
       'format': 'geojson',
       'fields': [
         {
@@ -63,8 +63,26 @@ const v2Expected = {
     }, {
       'attribution': 'Similarion',
       'weight': 0,
+      'name': 'Rohan Kingdoms',
+      'url': `https://staging-dot-elastic-layer.appspot.com/files/rohan_v2.json?elastic_tile_service_tos=agree`,
+      'format': 'topojson',
+      'fields': [
+        {
+          'name': 'label_en',
+          'description': 'Kingdom name (English)',
+        },
+      ],
+      'created_at': '1200-02-28T17:13:39.456456',
+      'tags': [],
+      'id': 'rohan_v2.json',
+      'meta': {
+        'feature_collection_path': 'data',
+      },
+    }, {
+      'attribution': 'Similarion',
+      'weight': 0,
       'name': 'Shire regions',
-      'url': `https://staging-dot-elastic-layer.appspot.com/files/shire_v2.json?elastic_tile_service_tos=agree`,
+      'url': `https://staging-dot-elastic-layer.appspot.com/blob/333333333333?elastic_tile_service_tos=agree`,
       'format': 'geojson',
       'fields': [
         {
@@ -89,7 +107,7 @@ const prodExpected = {
       'attribution': 'Similarion',
       'weight': 0,
       'name': 'Gondor Kingdoms',
-      'url': `https://vector.maps.elastic.co/files/gondor_v2.json?elastic_tile_service_tos=agree`,
+      'url': `https://vector.maps.elastic.co/blob/222222222222?elastic_tile_service_tos=agree`,
       'format': 'geojson',
       'fields': [
         {
@@ -100,6 +118,24 @@ const prodExpected = {
       'created_at': '1200-02-28T17:13:39.288909',
       'tags': [],
       'id': 222222222222,
+    }, {
+      'attribution': 'Similarion',
+      'weight': 0,
+      'name': 'Rohan Kingdoms',
+      'url': `https://vector.maps.elastic.co/files/rohan_v2.json?elastic_tile_service_tos=agree`,
+      'format': 'topojson',
+      'fields': [
+        {
+          'name': 'label_en',
+          'description': 'Kingdom name (English)',
+        },
+      ],
+      'created_at': '1200-02-28T17:13:39.456456',
+      'tags': [],
+      'id': 'rohan_v2.json',
+      'meta': {
+        'feature_collection_path': 'data',
+      },
     },
   ],
 };
@@ -110,7 +146,7 @@ const safeDuplicatesExpected = {
     'attribution': 'Similarion',
     'weight': 0,
     'name': 'Isengard Regions',
-    'url': 'https://staging-dot-elastic-layer.appspot.com/files/isengard_v1.json?elastic_tile_service_tos=agree',
+    'url': 'https://staging-dot-elastic-layer.appspot.com/blob/111111111111?elastic_tile_service_tos=agree',
     'format': 'geojson',
     'fields': [
       {

--- a/test/generate-vectors.js
+++ b/test/generate-vectors.js
@@ -30,6 +30,9 @@ const v2Expected = [{
   'src': 'data/gondor_v2.json',
   'dest': 'dist/blob/222222222222',
 }, {
+  'src': 'data/rohan_v2.json',
+  'dest': 'dist/files/rohan_v2.json',
+}, {
   'src': 'data/shire_v2.json',
   'dest': 'dist/files/shire_v2.json',
 }, {
@@ -43,11 +46,17 @@ const prodExpected = [{
 }, {
   'src': 'data/gondor_v2.json',
   'dest': 'dist/blob/222222222222',
+}, {
+  'src': 'data/rohan_v2.json',
+  'dest': 'dist/files/rohan_v2.json',
 }];
 
 const v3Expected = [{
   'src': 'data/gondor_v3.json',
   'dest': 'dist/files/gondor_v3.json',
+}, {
+  'src': 'data/rohan_v2.json',
+  'dest': 'dist/files/rohan_v2.json',
 }, {
   'src': 'data/shire_v2.json',
   'dest': 'dist/files/shire_v2.json',


### PR DESCRIPTION
To resolve issues with older versions of Kibana (e.g. 5.x), we should continue to maintain the `blob/{id}` URL path for layers in the current manifests. After the migration period is over, new layer sources can be added without an `id` field. In that case, the new layer will appear in the manifest as `files/{filename}`. 

When we release a new major version of EMS `>v2`, we can create manifests using the `files/{filename}` URL path in the manifest.