### PR TITLE
Use rsync instead of cp for deploying to buckets

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -131,11 +131,11 @@ else
     fi
 
     # Copy catalogue manifest
-    echo "Copying $PWD/dist/catalogue* to gs://$CATALOGUE_BUCKET"
-    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" cp -r -Z $PWD/dist/catalogue/* "gs://$CATALOGUE_BUCKET"
+    echo "Syncing $PWD/dist/catalogue* to gs://$CATALOGUE_BUCKET"
+    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" rsync -d -r -Z $PWD/dist/catalogue/* "gs://$CATALOGUE_BUCKET"
 
     # Copy vector files
-    echo "Copying $PWD/dist/vector* to gs://$VECTOR_BUCKET"
-    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" cp -r -Z $PWD/dist/vector/* "gs://$VECTOR_BUCKET"
+    echo "Syncing $PWD/dist/vector* to gs://$VECTOR_BUCKET"
+    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" rsync -d -r -Z $PWD/dist/vector/* "gs://$VECTOR_BUCKET"
 
 fi


### PR DESCRIPTION
If we continue to use `cp` to copy files, we run the risk of leaving old, unused files on the bucket. Using `rsync` with the `-d` flag will copy files from the locally generated directories (`dist/`) and remove files from the bucket that don't exist in `dist`. 

This may appear dangerous, but we create archives of our production deployments on a separate bucket so we can always restore data from the archive if something goes wrong.