### PR TITLE
Revert to using `cp` to copy files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -131,11 +131,11 @@ else
     fi
 
     # Copy catalogue manifest
-    echo "Syncing $PWD/dist/catalogue* to gs://$CATALOGUE_BUCKET"
-    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" rsync -d -r -Z $PWD/dist/catalogue/* "gs://$CATALOGUE_BUCKET"
+    echo "Copying $PWD/dist/catalogue* to gs://$CATALOGUE_BUCKET"
+    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" cp -r -Z $PWD/dist/catalogue/* "gs://$CATALOGUE_BUCKET"
 
     # Copy vector files
-    echo "Syncing $PWD/dist/vector* to gs://$VECTOR_BUCKET"
-    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" rsync -d -r -Z $PWD/dist/vector/* "gs://$VECTOR_BUCKET"
+    echo "Copying $PWD/dist/vector* to gs://$VECTOR_BUCKET"
+    gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" cp -r -Z $PWD/dist/vector/* "gs://$VECTOR_BUCKET"
 
 fi


### PR DESCRIPTION
`gsutil rsync` does not have an equivalent to the `cp -Z` flag to gzip files stored on the bucket. The `rsync -J` flag only appears to compress files during upload and leaves uncompressed files on the server.

My preference is to keep using `gsutil cp` and manually delete files in the bucket if necessary. 

In the future we may choose to create gzipped files in the `dist` directory using JavaScript. Then we can use `rsync`.   