### PR TITLE
Update zip codes dataset

### DIFF
--- a/sources/us/README.md
+++ b/sources/us/README.md
@@ -1,0 +1,9 @@
+# USA Zip Codes
+
+Zip codes for the United States are available as Zip Code Tabulation Areas (ZCTAs) created by the US Census Bureau.  The ZCTAs are extremely detailed and the 2017 shapefile is >500MB. To make ZCTAs suitable for visualizing in Elastic Maps Service we have to dramatically generalize the shapes. Additionally, we publish the layer as TopoJSON so it is only available in `v2` of the Elastic Maps Service (Kibana v6.2+). The ZCTA shapefile can be downloaded from the link in the `data` field in the `sources/us/zip_codes.hjson` file.
+
+The mapshaper command line program can be used to simplify the shapes while maintaining topology and the conversion from shapefile to TopoJSON. Mapshaper requires Node.js and can be installed with `npm i -g mapshaper`. 
+
+`mapshaper-xl ~/Downloads/tl_2017_us_zcta510/tl_2017_us_zcta510.shp snap -simplify 0.1% -filter-fields ZCTA5CE10 -rename-fields zip=ZCTA5CE10 -o format=topojson data/usa_zip_codes_v2.json`
+
+Note, it's likely that not all zip codes used by the US Postal Service have a corresponding boundary in the ZCTA. 

--- a/sources/us/zip_codes.hjson
+++ b/sources/us/zip_codes.hjson
@@ -2,7 +2,7 @@
   versions: '>=2'
   production: true
   type: http
-  note: Zip Code Tabulation Areas from the Census TIGERWEB
+  note: Zip Code Tabulation Areas from the Census TIGERWEB (simplified)
   website: https://www.census.gov/geo/reference/zctas.html
   data: ftp://ftp2.census.gov/geo/tiger/TIGER2017/ZCTA5/tl_2017_us_zcta510.zip
   fieldMapping: [
@@ -20,10 +20,10 @@
   {
     type: topojson
   }
-  attribution: US Census Bureau
+  attribution: "[US Census Bureau](https://www.census.gov/geo/reference/zctas.html)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
   ttl: 108000
   weight: 0
-  createdAt: "2018-01-26T17:16:00.275510"
+  createdAt: "2018-09-12T16:20:47.303827"
   id: 5700305828184064
   filename: usa_zip_codes_v2.json
 }


### PR DESCRIPTION
Fixes #6.

This PR updates the zip codes vector layer and includes instructions for creating the data layer from the US Census Bureau zip code tabulation areas.

A cursory review of the differences between this file and the one in production shows many additional zip codes that were previously missing.

There also appear to be a few dozen zip codes in the production layer that are not in the data in the PR. I spot checked a sample of these with the USPS website and found that most appear to be 
a) non-existent; or
b) likely too small to constitute a boundary

The processed TopoJSON file can differ dramatically from the source file at large scales. The ZCTA shapefile from the Census is >500MB. To use it within Kibana, we must generalize the boundaries liberally. 

Just to give an idea these GIFs show the difference between the TopoJSON layer I've created and the full resolution shapefile from the Census Bureau at different scales.

GIF comparing Census shapefile and Mapshaper TopoJSON centered on New York City at zoom level 5
![GIF comparing Census shapefile and Mapshaper TopoJSON centered on New York City at zoom level 5](https://user-images.githubusercontent.com/1638483/37677561-a3bc8828-2c38-11e8-921c-cc51eae4e08b.gif)

GIF comparing Census shapefile and Mapshaper TopoJSON centered on New York City at zoom level 7
![GIF comparing Census shapefile and Mapshaper TopoJSON centered on New York City at zoom level 7](https://user-images.githubusercontent.com/1638483/37677650-e1410106-2c38-11e8-9d00-a3ed81735adf.gif)

GIF comparing Census shapefile and Mapshaper TopoJSON centered on New York City at zoom level 10
![GIF comparing Census shapefile and Mapshaper TopoJSON centered on New York City at zoom level 10](https://user-images.githubusercontent.com/1638483/37677706-09b3fc2e-2c39-11e8-95f9-8c3a2b613f1c.gif)