### PR TITLE
Add field types to sources

### DIFF
--- a/schema/source_schema.json
+++ b/schema/source_schema.json
@@ -41,7 +41,8 @@
     "fieldMapping": {
       "description":
         "Specifies map source field names or properties to elastic map service properties",
-      "type": "array"
+      "type": "array",
+      "items": { "$ref": "#/definitions/fieldMap" }
     },
     "website": {
       "type": "string"
@@ -114,6 +115,33 @@
         },
         "share-alike": {
           "type": "boolean"
+        }
+      }
+    },
+    "fieldMap": {
+      "description": "Specifies type, name, source, destination, and description of a field.",
+      "type": "object",
+      "required": [
+        "type",
+        "name",
+        "desc"
+      ],
+      "properties": {
+        "type": {
+          "description": "Type of field. Starting in Kibana v6.5 `id` fields are available as Join Fields in Kibana. By default, `property` fields cannot be used as a Join Field.",
+          "type": "string",
+          "enum": [
+            "id",
+            "property"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of field in vector data"
+        },
+        "desc": {
+          "type": "string",
+          "description": "Human readable field name"
         }
       }
     },

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -109,7 +109,7 @@ function manifestLayerV1(data, hostname) {
     url: `https://${hostname}/${urlPath}?elastic_tile_service_tos=agree`,
     format: data.conform.type,
     fields: data.fieldMapping.map(fieldMap => ({
-      name: fieldMap.dest,
+      name: fieldMap.name,
       description: fieldMap.desc,
     })),
     created_at: data.createdAt,

--- a/sources/au/states.hjson
+++ b/sources/au/states.hjson
@@ -7,15 +7,13 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: State name (English)
         }
     ]

--- a/sources/ca/provinces.hjson
+++ b/sources/ca/provinces.hjson
@@ -7,21 +7,18 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Province name (English)
         }
         {
+            type: property
             name: label_fr
-            source: label_fr
-            dest: label_fr
             desc: Province name (French)
         }
     ]

--- a/sources/ch/switzerland-cantons.hjson
+++ b/sources/ch/switzerland-cantons.hjson
@@ -7,39 +7,33 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Canton name (English)
         }
         {
+            type: property
             name: label_de
-            source: label_de
-            dest: label_de
             desc: Canton name (German)
         }
         {
+            type: property
             name: label_fr
-            dest: label_fr
-            source: label_fr
             desc: Canton name (French)
         }
         {
+            type: property
             name: label_it
-            dest: label_it
-            source: label_it
             desc: Canton name (Italian)
         }
         {
+            type: property
             name: label_rm
-            dest: label_rm
-            source: label_rm
             desc: Canton name (Romansh)
         }
     ]

--- a/sources/de/states.hjson
+++ b/sources/de/states.hjson
@@ -7,21 +7,18 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: State name (English)
         }
         {
+            type: property
             name: label_de
-            source: label_de
-            dest: label_de
             desc: State name (German)
         }
     ]

--- a/sources/es/provinces.hjson
+++ b/sources/es/provinces.hjson
@@ -7,21 +7,18 @@
     attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Community/Province name (English)
         }
         {
+            type: property
             name: label_es
-            source: label_es
-            dest: label_es
             desc: Community/Province name (Spanish)
         }
     ]

--- a/sources/fi/regions.hjson
+++ b/sources/fi/regions.hjson
@@ -7,27 +7,23 @@
     attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Region name (English)
         }
         {
+            type: property
             name: label_fi
-            source: label_fi
-            dest: label_fi
             desc: Region name (Finnish)
         }
         {
+            type: property
             name: label_sv
-            source: label_sv
-            dest: label_sv
             desc: Region name (Swedish)
         }
     ]

--- a/sources/fr/departments.hjson
+++ b/sources/fr/departments.hjson
@@ -7,27 +7,23 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: id
             name: insee
-            source: insee
-            dest: insee
             desc: INSEE department identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Department name (English)
         }
         {
+            type: property
             name: label_fr
-            source: label_fr
-            dest: label_fr
             desc: Department name (French)
         }
     ]

--- a/sources/ie/ireland-counties.hjson
+++ b/sources/ie/ireland-counties.hjson
@@ -7,27 +7,23 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: id
             name: logainm
-            source: logainm
-            dest: logainm
             desc: Logainm identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: County/Province name (English)
         }
         {
+            type: property
             name: label_ga
-            source: label_ga
-            dest: label_ga
             desc: County/Province name (Irish)
         }
     ]

--- a/sources/jp/prefectures.hjson
+++ b/sources/jp/prefectures.hjson
@@ -7,27 +7,23 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: id
             name: dantai
-            source: dantai
-            dest: dantai
             desc: Dantai administrative division code
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Prefecture name (English)
         }
         {
+            type: property
             name: label_ja
-            source: label_ja
-            dest: label_ja
             desc: Prefecture name (Japanese)
         }
     ]

--- a/sources/nl/provinces.hjson
+++ b/sources/nl/provinces.hjson
@@ -7,21 +7,18 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Province name (English)
         }
         {
+            type: property
             name: label_nl
-            source: label_nl
-            dest: label_nl
             desc: Province name (Dutch)
         }
     ]

--- a/sources/no/counties.hjson
+++ b/sources/no/counties.hjson
@@ -7,27 +7,23 @@
     attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: County name (English)
         }
         {
+            type: property
             name: label_nn
-            source: label_nn
-            dest: label_nn
             desc: County name (Nynorsk)
         }
         {
+            type: property
             name: label_nb
-            source: label_nb
-            dest: label_nb
             desc: County name (Bokmål)
         }
     ]

--- a/sources/se/counties.hjson
+++ b/sources/se/counties.hjson
@@ -7,21 +7,18 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: County name (English)
         }
         {
+            type: property
             name: label_sv
-            source: label_sv
-            dest: label_sv
             desc: County name (Swedish)
         }
     ]

--- a/sources/uk/subdivisions.hjson
+++ b/sources/uk/subdivisions.hjson
@@ -8,21 +8,18 @@
     data: See README
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: id
             name: gss
-            source: gss
-            dest: gss
             desc: GSS code
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Subdivision name (English)
         }
     ]

--- a/sources/us/counties.hjson
+++ b/sources/us/counties.hjson
@@ -7,27 +7,23 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: fips_6_4
-            source: fips_6_4
-            dest: fips_6_4
             desc: FIPS county code
         }
         {
+            type: id
             name: gnis
-            source: gnis
-            dest: gnis
             desc: GNIS ID
         }
         {
+            type: id
             name: viaf
-            source: viaf
-            dest: viaf
             desc: VIAF ID
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: County name (English)
         }
     ]

--- a/sources/us/states.hjson
+++ b/sources/us/states.hjson
@@ -7,22 +7,19 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
-            name: name
-            source: name
-            dest: name
-            desc: State name
+            type: id
+            name: postal
+            desc: Two letter abbreviation
         }
         {
-            name: postal
-            source: postal
-            dest: postal
-            desc: Two letter abbreviation
+            type: id
+            name: name
+            desc: State name
         }
     ]
     query: {

--- a/sources/us/states.hjson
+++ b/sources/us/states.hjson
@@ -17,7 +17,11 @@
             desc: Two letter abbreviation
         }
         {
+<<<<<<< HEAD
             type: property
+=======
+            type: id
+>>>>>>> Add field types to sources.
             name: name
             desc: State name
         }

--- a/sources/us/states.hjson
+++ b/sources/us/states.hjson
@@ -17,7 +17,7 @@
             desc: Two letter abbreviation
         }
         {
-            type: id
+            type: property
             name: name
             desc: State name
         }

--- a/sources/us/states.hjson
+++ b/sources/us/states.hjson
@@ -17,11 +17,7 @@
             desc: Two letter abbreviation
         }
         {
-<<<<<<< HEAD
             type: property
-=======
-            type: id
->>>>>>> Add field types to sources.
             name: name
             desc: State name
         }

--- a/sources/us/zip_codes.hjson
+++ b/sources/us/zip_codes.hjson
@@ -7,9 +7,8 @@
   data: ftp://ftp2.census.gov/geo/tiger/TIGER2017/ZCTA5/tl_2017_us_zcta510.zip
   fieldMapping: [
     {
+      type: id
       name: zip
-      source: zcta5
-      dest: zip
       desc: 5-digit zip code
     }
   ]

--- a/sources/world/world_countries.hjson
+++ b/sources/world/world_countries.hjson
@@ -1,31 +1,27 @@
 {
   versions: '>=1'
   production: true
-    type: http
+  type: http
   note: Administrative map units from Natural Earth Data. URLs listed at http://geojson.xyz
   data: https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_map_units.geojson
   attribution: "[Made with NaturalEarth](http://www.naturalearthdata.com/about/terms-of-use)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
   fieldMapping: [
     {
+      type: id
       name: iso2
-      source: iso_a2,
-      dest: iso2
       desc: Two letter abbreviation
     }
     {
-      name: name
-      source: name
-      dest: name
-      desc: Country name
-    }
-    {
+      type: id
       name: iso3
-      source: iso_a3
-      dest: iso3
       desc: Three letter abbreviation
     }
+    {
+      type: property
+      name: name
+      desc: Country name
+    }
   ]
-
   website: http://naturalearthdata.comhttp://www.naturalearthdata.com/downloads/10m-cultural-vectors/10m-admin-0-details/
   license:
   {

--- a/sources/zh/provinces.hjson
+++ b/sources/zh/provinces.hjson
@@ -7,27 +7,23 @@
     attribution: "© [OpenStreetMap](https://www.openstreetmap.org/copyright) contributors|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: id
             name: division_code
-            source: division_code
-            dest: division_code
             desc: China administrative division code
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Province name (English)
         }
         {
+            type: property
             name: label_zh
-            source: label_zh
-            dest: label_zh
             desc: Province name (Chinese)
         }
     ]

--- a/templates/source_template.hjson
+++ b/templates/source_template.hjson
@@ -7,15 +7,13 @@
     attribution: "[© OpenStreetMap contributors](https://www.openstreetmap.org/copyright)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"
     fieldMapping: [
         {
+            type: id
             name: iso_3166_2
-            source: iso_3166_2
-            dest: iso_3166_2
             desc: ISO-3166-2 identifier
         }
         {
+            type: property
             name: label_en
-            source: label_en
-            dest: label_en
             desc: Subdivision name (English)
         }
     ]

--- a/test/fixtures/duplicateHumanNames.json
+++ b/test/fixtures/duplicateHumanNames.json
@@ -8,9 +8,8 @@
   "humanReadableName": "Isengard Regions",
   "fieldMapping": [
     {
+      "type": "property",
       "name": "label_en",
-      "source": "label_en",
-      "dest": "label_en",
       "desc": "Region name (English)"
     }
   ],
@@ -31,9 +30,8 @@
   "humanReadableName": "Isengard Regions",
   "fieldMapping": [
     {
+      "type": "property",
       "name": "label_en",
-      "source": "label_en",
-      "dest": "label_en",
       "desc": "Region name (English)"
     }
   ],

--- a/test/fixtures/duplicateIds.json
+++ b/test/fixtures/duplicateIds.json
@@ -8,9 +8,8 @@
   "humanReadableName": "Mordor Regions",
   "fieldMapping": [
     {
+      "type": "property",
       "name": "label_en",
-      "source": "label_en",
-      "dest": "label_en",
       "desc": "Region name (English)"
     }
   ],
@@ -31,9 +30,8 @@
   "humanReadableName": "Isengard Regions",
   "fieldMapping": [
     {
+      "type": "property",
       "name": "label_en",
-      "source": "label_en",
-      "dest": "label_en",
       "desc": "Region name (English)"
     }
   ],

--- a/test/fixtures/sources.json
+++ b/test/fixtures/sources.json
@@ -9,9 +9,8 @@
     "humanReadableName": "Mordor Regions",
     "fieldMapping": [
       {
+        "type": "property",
         "name": "label_en",
-        "source": "label_en",
-        "dest": "label_en",
         "desc": "Region name (English)"
       }
     ],
@@ -33,9 +32,8 @@
     "humanReadableName": "Gondor Kingdoms",
     "fieldMapping": [
       {
+        "type": "property",
         "name": "label_en",
-        "source": "label_en",
-        "dest": "label_en",
         "desc": "Kingdom name (English)"
       }
     ],
@@ -57,9 +55,8 @@
     "humanReadableName": "Gondor Kingdoms",
     "fieldMapping": [
       {
+        "type": "property",
         "name": "label_en",
-        "source": "label_en",
-        "dest": "label_en",
         "desc": "Kingdom name (English)"
       }
     ],
@@ -80,9 +77,8 @@
     "humanReadableName": "Rohan Kingdoms",
     "fieldMapping": [
       {
+        "type": "property",
         "name": "label_en",
-        "source": "label_en",
-        "dest": "label_en",
         "desc": "Kingdom name (English)"
       }
     ],
@@ -103,15 +99,12 @@
     "humanReadableName": "Shire regions",
     "fieldMapping": [
       {
+        "type": "property",
         "name": "label_en",
-        "source": "label_en",
-        "dest": "label_en",
         "desc": "Region name (English)"
       },
       {
         "name": "label_ws",
-        "source": "label_ad",
-        "dest": "label_ws",
         "desc": "Region name (Westron)"
       }
     ],


### PR DESCRIPTION
This PR adds field types to the data sources. A field can have either type `id` or `property`. In the future we want to discourage the use of `property` fields as Join Fields in Kibana region maps and the GIS app. `id` fields are meant to be used for Join Fields instead as they are usually distinct defined by a standard such as the ISO 3166 country codes.  

This has no effect on `v1` and `v2` manifests.

Fixes #47. 