### PR TITLE
Add legacy_ids array to v6.6 manifest

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -159,6 +159,7 @@ function manifestLayerV6(data, hostname, opts) {
       };
     }),
     fields: fields,
+    legacy_ids: [ data.name ],
     layer_name: data.humanReadableName,
   };
   return layer;

--- a/test/manifest-v6.js
+++ b/test/manifest-v6.js
@@ -61,6 +61,9 @@ const v6Expected = {
           },
         },
       ],
+      'legacy_ids': [
+        'gondor',
+      ],
       'layer_name': {
         'en': 'Gondor Kingdoms',
         'de': 'Gondor',
@@ -105,6 +108,9 @@ const v6Expected = {
             'zh': '名称 (en)',
           },
         },
+      ],
+      'legacy_ids': [
+        'rohan',
       ],
       'layer_name': {
         'en': 'Rohan Kingdoms',
@@ -159,6 +165,9 @@ const v6Expected = {
             'zh': '名称 (ws)',
           },
         },
+      ],
+      'legacy_ids': [
+        'shire',
       ],
       'layer_name': {
         'en': 'Shire regions',
@@ -218,6 +227,9 @@ const prodExpected = {
           },
         },
       ],
+      'legacy_ids': [
+        'gondor',
+      ],
       'layer_name': {
         'en': 'Gondor Kingdoms',
         'de': 'Gondor',
@@ -262,6 +274,9 @@ const prodExpected = {
             'zh': '名称 (en)',
           },
         },
+      ],
+      'legacy_ids': [
+        'rohan',
       ],
       'layer_name': {
         'en': 'Rohan Kingdoms',
@@ -317,6 +332,9 @@ const fieldInfoFallbackExpected = {
           },
         },
       ],
+      'legacy_ids': [
+        'gondor',
+      ],
       'layer_name': {
         'en': 'Gondor Kingdoms',
         'de': 'Gondor',
@@ -358,6 +376,9 @@ const fieldInfoFallbackExpected = {
             'en': 'Kingdom name (English)',
           },
         },
+      ],
+      'legacy_ids': [
+        'rohan',
       ],
       'layer_name': {
         'en': 'Rohan Kingdoms',
@@ -415,6 +436,9 @@ const fieldInfoMissingNameExpected = {
           },
         },
       ],
+      'legacy_ids': [
+        'gondor',
+      ],
       'layer_name': {
         'en': 'Gondor Kingdoms',
         'de': 'Gondor',
@@ -458,6 +482,9 @@ const fieldInfoMissingNameExpected = {
             'en': 'Kingdom name (English)',
           },
         },
+      ],
+      'legacy_ids': [
+        'rohan',
       ],
       'layer_name': {
         'en': 'Rohan Kingdoms',


### PR DESCRIPTION
Fixes #61.

All layers in the v1 and v2 manifests can be uniquely referenced in Kibana saved objects using the `name` field. This PR will allow us to map the `name` field in the saved object to the appropriate layer via `legacy_ids` in the v6.6 manifest. 

Since all saved objects include the `name` field there is no need to add any additional strings to the `legacy_ids` array at this time. However, we want to retain the ability to add additional strings to the `legacy_ids` array as needed in the future.