### PR TITLE
Minify vector files copied to dist/

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,5 +68,6 @@ for (const version of constants.VERSIONS) {
 
 for (const file of vectorFiles) {
   // file is an array of [dest, src]
-  fs.copyFileSync(file[1], file[0]);
+  const vector = JSON.parse(fs.readFileSync(file[1]));
+  fs.writeFileSync(file[0], JSON.stringify(vector), 'utf8');
 }


### PR DESCRIPTION
Fixes #50.

Vector files stored in [`data/`]() may include whitespace and line breaks for human-readability and better diffing. 

We want to ensure that any unnecessary whitespace and line breaks are removed from vector files published to production to decrease file size and improve performance for the end-user. 

There is no rush on this and we can merge after v6.6 is published.