### PR TITLE
Match plural convention for `en` names for USA Counties

### DIFF
--- a/sources/us/README.md
+++ b/sources/us/README.md
@@ -16,3 +16,5 @@ mapshaper -i ~/Downloads/cb_2017_us_county_20m/cb_2017_us_county_20m.shp \
 -o format=topojson prettify id-field=fips \
 ./data/usa_counties_v2.topo.json
 ```
+
+*Note: To maintain an established precedent with layer names in the English language, the `en`, `en-ca`, and `en-gb` human readable names in `counties.hjson` have been manually adjusted from singular to plural format.*

--- a/sources/us/counties.hjson
+++ b/sources/us/counties.hjson
@@ -49,9 +49,9 @@
         da: county i USA
         de: County der Vereinigten Staaten
         el: κομητεία των ΗΠΑ
-        en: USA County
-        en-ca: USA County
-        en-gb: USA County
+        en: USA Counties
+        en-ca: USA Counties
+        en-gb: USA Counties
         eo: kantono de Usono
         es: condado de Estados Unidos
         eu: Ameriketako Estatu Batuetako konderri


### PR DESCRIPTION
The current precedent for human readable layer names in English is plural. We should continue this precedent.