### PR TITLE
Fix semver range for France

### DIFF
--- a/sources/fr/departments_v1.hjson
+++ b/sources/fr/departments_v1.hjson
@@ -1,5 +1,5 @@
 {
-    versions: '>=1 - <7'
+    versions: '1 - 6.7'
     production: true
     countryCode: FR
     type: http


### PR DESCRIPTION
Semver ranges with a hyphen and inclusive and do not accept operators such as < and >.