### PR TITLE
Publish 7.1 manifest

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -9,5 +9,5 @@ module.exports = Object.freeze({
   VECTOR_STAGING_HOST: 'vector-staging.maps.elastic.co',
   TILE_PRODUCTION_HOST: 'tiles.maps.elastic.co',
   TILE_STAGING_HOST: 'tiles-maps-stage.elastic.co',
-  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0'],
+  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0','v7.1'],
 });

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -30,11 +30,14 @@ function generateCatalogueManifest(opts) {
   if (!semver.valid(semver.coerce(opts.version))) {
     throw new Error('A valid version parameter must be defined');
   }
+  const tilesManifest = semver.lt(semver.coerce(opts.version), '7.1.0')
+    ? { id: 'tiles_v2', version: 'v2' }
+    : { id: 'tiles', version: 'v7.1' };
   const manifest = {
     services: [{
-      id: 'tiles_v2',
+      id: tilesManifest.id,
       name: 'Elastic Maps Tile Service',
-      manifest: `https://${opts.tileHostname}/v2/manifest`,
+      manifest: `https://${opts.tileHostname}/${tilesManifest.version}/manifest`,
       type: 'tms',
     }, {
       id: 'geo_layers',


### PR DESCRIPTION
Publish a new catalogue manifest with support for [v7.1 tiles manifest](https://tiles.maps.elastic.co/v7.1/manifest).