### PR TITLE
Update staging URL for tiles manifest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ set +x
 
 # Expected env variables:
 # * [GCE_ACCOUNT] - credentials for the google service account (JSON blob)
-# * [TILE_HOST] - "tiles.maps.elastic.co" or "tiles-maps-stage.elastic.co" (default)
+# * [TILE_HOST] - "tiles.maps.elastic.co" or "tiles.maps.elstc.co" (default)
 # * [VECTOR_HOST] - "vector.maps.elastic.co" or "vector-staging.maps.elastic.co" (default)
 # * [CATALOGUE_BUCKET] - "elastic-ems-prod-files-catalogue" or "elastic-ems-prod-files-catalogue-staging"
 # * [VECTOR_BUCKET] - "elastic-ems-prod-files-vector" or "elastic-ems-prod-files-vector-staging".
@@ -32,7 +32,7 @@ if [[ -z "${VECTOR_HOST}" ]]; then
 fi
 
 if [[ -z "${TILE_HOST}" ]]; then
-    TILE_HOST="tiles-maps-stage.elastic.co"
+    TILE_HOST="tiles.maps.elstc.co"
     echo "TILE_HOST is not set. Defaulting to '${TILE_HOST}'."
 fi
 

--- a/deployStaging.sh
+++ b/deployStaging.sh
@@ -20,7 +20,7 @@ fi
 
 export EMS_PROJECT="files"
 
-export TILE_HOST="tiles-maps-stage.elastic.co"
+export TILE_HOST="tiles.maps.elstc.co"
 export VECTOR_HOST="vector-staging.maps.elastic.co"
 export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue-staging
 export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector-staging

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -8,6 +8,6 @@ module.exports = Object.freeze({
   VECTOR_PRODUCTION_HOST: 'vector.maps.elastic.co',
   VECTOR_STAGING_HOST: 'vector-staging.maps.elastic.co',
   TILE_PRODUCTION_HOST: 'tiles.maps.elastic.co',
-  TILE_STAGING_HOST: 'tiles-maps-stage.elastic.co',
+  TILE_STAGING_HOST: 'tiles.maps.elstc.co',
   VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0','v7.2'],
 });

--- a/test/manifest-v1.js
+++ b/test/manifest-v1.js
@@ -148,14 +148,14 @@ tap('v1 tests', t => {
 
   const v1Catalogue = generateCatalogueManifest({
     version: 'v1',
-    tileHostname: 'tiles-maps-stage.elastic.co',
+    tileHostname: 'tiles.maps.elstc.co',
     vectorHostname: 'vector-staging.maps.elastic.co',
   });
   t.deepEquals(v1Catalogue, {
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',
-      manifest: 'https://tiles-maps-stage.elastic.co/v2/manifest',
+      manifest: 'https://tiles.maps.elstc.co/v2/manifest',
       type: 'tms',
     }, {
       id: 'geo_layers',

--- a/test/manifest-v2.js
+++ b/test/manifest-v2.js
@@ -193,14 +193,14 @@ tap('v2 tests', t => {
 
   const v2Catalogue = generateCatalogueManifest({
     version: 'v2',
-    tileHostname: 'tiles-maps-stage.elastic.co',
+    tileHostname: 'tiles.maps.elstc.co',
     vectorHostname: 'vector-staging.maps.elastic.co',
   });
   t.deepEquals(v2Catalogue, {
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',
-      manifest: 'https://tiles-maps-stage.elastic.co/v2/manifest',
+      manifest: 'https://tiles.maps.elstc.co/v2/manifest',
       type: 'tms',
     }, {
       id: 'geo_layers',

--- a/test/manifest-v6.js
+++ b/test/manifest-v6.js
@@ -577,14 +577,14 @@ tap('v6 tests', t => {
 
   const v6Catalogue = generateCatalogueManifest({
     version: 'v6.6',
-    tileHostname: 'tiles-maps-stage.elastic.co',
+    tileHostname: 'tiles.maps.elstc.co',
     vectorHostname: 'vector-staging.maps.elastic.co',
   });
   t.deepEquals(v6Catalogue, {
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',
-      manifest: 'https://tiles-maps-stage.elastic.co/v2/manifest',
+      manifest: 'https://tiles.maps.elstc.co/v2/manifest',
       type: 'tms',
     }, {
       id: 'geo_layers',


### PR DESCRIPTION
Under the new tile server architecture, the staging URLs for the tiles need to be updated. This does not affect production users in any way.