### PR TITLE
Add ci job for feature-layers branch

### DIFF
--- a/.ci/jobs/elastic+ems-file-service+feature-layers.yml
+++ b/.ci/jobs/elastic+ems-file-service+feature-layers.yml
@@ -1,0 +1,29 @@
+---
+- job:
+    name: elastic+ems-file-service+feature-layers
+    display-name: 'elastic / ems-file-service # feature-layers'
+    description: Build and deploy feature-layers branch to development server using ./deployDev.sh.
+    parameters:
+    - string:
+      name: branch_identifier
+      default: refs/heads/feature-layers
+      description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+        &lt;commitId&gt;, etc.)
+    triggers:
+    - github
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -e
+        set +x
+
+        export GPROJECT=elastic-ems-dev
+        VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/jenkins
+
+        export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
+        unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
+
+        # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH
+        # Run EMS script, set in the template parameter
+        ./deployDev.sh

--- a/.ci/jobs/elastic+ems-file-service+feature-layers.yml
+++ b/.ci/jobs/elastic+ems-file-service+feature-layers.yml
@@ -17,7 +17,7 @@
         set -e
         set +x
 
-        export GPROJECT=elastic-ems-dev
+        export GPROJECT=elastic-bekitzur
         VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/jenkins
 
         export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")

--- a/deployDev.sh
+++ b/deployDev.sh
@@ -21,7 +21,6 @@ fi
 export EMS_PROJECT="emsfiles"
 
 export TILE_HOST="tiles.maps.elastic.co"
-export VECTOR_HOST="storage.googleapis.com/${GPROJECT}-${EMS_PROJECT}-vector-dev"
 export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue-dev
 export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector-dev
 export VECTOR_HOST="storage.googleapis.com/${VECTOR_BUCKET}"

--- a/deployDev.sh
+++ b/deployDev.sh
@@ -24,6 +24,8 @@ export TILE_HOST="tiles.maps.elastic.co"
 export VECTOR_HOST="storage.googleapis.com/${GPROJECT}-${EMS_PROJECT}-vector-dev"
 export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue-dev
 export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector-dev
+export VECTOR_HOST="storage.googleapis.com/${VECTOR_BUCKET}"
+
 
 unset ARCHIVE_BUCKET
 

--- a/deployDev.sh
+++ b/deployDev.sh
@@ -10,7 +10,7 @@ set -e
 set +x
 
 # Expected env variables:
-# * GPROJECT - e.g. "elastic-ems"
+# * GPROJECT - e.g. "elastic-bekitzur"
 # * GCE_ACCOUNT - credentials for the google service account (JSON blob)
 
 if [[ -z "${GPROJECT}" ]]; then
@@ -18,12 +18,12 @@ if [[ -z "${GPROJECT}" ]]; then
     exit 1
 fi
 
-export EMS_PROJECT="feature-layers"
+export EMS_PROJECT="emsfiles"
 
 export TILE_HOST="tiles.maps.elastic.co"
-export VECTOR_HOST="storage.googleapis.com/${GPROJECT}-${EMS_PROJECT}-vector"
-export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue
-export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector
+export VECTOR_HOST="storage.googleapis.com/${GPROJECT}-${EMS_PROJECT}-vector-dev"
+export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue-dev
+export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector-dev
 
 unset ARCHIVE_BUCKET
 

--- a/deployDev.sh
+++ b/deployDev.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -e
+set +x
+
+# Expected env variables:
+# * GPROJECT - e.g. "elastic-ems"
+# * GCE_ACCOUNT - credentials for the google service account (JSON blob)
+
+if [[ -z "${GPROJECT}" ]]; then
+    echo "GPROJECT is not set, e.g. 'GPROJECT=elastic-bekitzur'"
+    exit 1
+fi
+
+export EMS_PROJECT="feature-layers"
+
+export TILE_HOST="tiles.maps.elastic.co"
+export VECTOR_HOST="storage.googleapis.com/${GPROJECT}-${EMS_PROJECT}-vector"
+export CATALOGUE_BUCKET=${GPROJECT}-${EMS_PROJECT}-catalogue
+export VECTOR_BUCKET=${GPROJECT}-${EMS_PROJECT}-vector
+
+unset ARCHIVE_BUCKET
+
+./build.sh

--- a/deployProduction.sh
+++ b/deployProduction.sh
@@ -10,7 +10,7 @@ set -e
 set +x
 
 # Expected env variables:
-# * GPROJECT - e.g. "elastic-ems"
+# * GPROJECT - e.g. "elastic-bekitzur"
 # * GCE_ACCOUNT - credentials for the google service account (JSON blob)
 
 if [[ -z "${GPROJECT}" ]]; then

--- a/deployStaging.sh
+++ b/deployStaging.sh
@@ -10,7 +10,7 @@ set -e
 set +x
 
 # Expected env variables:
-# * GPROJECT - e.g. "elastic-ems"
+# * GPROJECT - e.g. "elastic-bekitzur"
 # * GCE_ACCOUNT - credentials for the google service account (JSON blob)
 
 if [[ -z "${GPROJECT}" ]]; then


### PR DESCRIPTION
To make new layer development easier to test, I propose developing new layers on the `feature-layers` branch. Any new layers being developed will be committed to this branch. This will build catalogue and vector manifests on a development storage bucket that are suitable for testing with Kibana by modifying the `map.manifestServiceUrl` parameter in `kibana.yml`. 

When ready to be reviewed and published, a pull request from the `feature-layers` branch will be opened against `master`. 

Code changes and pull requests not related to new layer development should continue to be created on new branches from `master`. The `feature-layers` branch would only be used for new vector layer development.

https://github.com/elastic/infra/issues/9313