### PR TITLE
Capitalize subdivision type in layer labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Whenever possible new vector layers should be created using a SPARQL query in [S
 1. Complete the `emsFormats` properties: `type` is either `geojson` or `topojson`, `file` is the filename specified above, `default` is `true` when there is only one format. Subsequent formats can be added but only one item in the array can have `default: true`. The other items must be `default: false` or omit `default` entirely.
 1. Copy and paste the SPARQL query from Sophox to the `query.sparql` field in the source file.
 1. Use the `scripts/wikidata-labels.js` script to list the `humanReadableName` languages from Wikidata (e.g. `node scripts/wikidata-labels.js Q33`). You should spot check these translations as some languages might lack specificity (e.g. `Provins` rather than `Kinas provinser`).
+1. We should maintain the current precedent for title casing `legacyIds` and English labels of the `humanReadableName`. This may need to be manually edited in the source (e.g. Paraguay Departments).
 1. All fields used by sources that do not follow the `label_<language_code>`  schema must have translations in (schema/fields.hjson). If necessary, use the `scripts/wikidata-labels.js` script to list translations and copy them to (schema/fields.hjson) (e.g. `node scripts/wikidata-labels P5097`).
 1. Use the following bash command to generate the timestamp for the `createdAt` field. Use `gdate` on Mac OSX.
 `date -u +"%Y-%m-%dT%H:%M:%S.%6N"`

--- a/sources/ar/argentina-provinces.hjson
+++ b/sources/ar/argentina-provinces.hjson
@@ -79,7 +79,7 @@
     }
     name: argentina_provinces
     legacyIds: [
-      Argentina provinces
+      Argentina Provinces
     ]
     humanReadableName: {
       ar: محافظة في الأرجنتين
@@ -93,7 +93,7 @@
       cy: Taleithiau&#39;r Ariannin
       da: Argentinas provinser
       de: Provinz Argentiniens
-      en: Argentina provinces
+      en: Argentina Provinces
       en-ca: Provinces of Argentina
       en-gb: province of Argentina
       eo: provinco de Argentino

--- a/sources/bo/bolivia-departments.hjson
+++ b/sources/bo/bolivia-departments.hjson
@@ -103,7 +103,7 @@
     }
     name: bolivia_departments
     legacyIds: [
-      Bolivia departments
+      Bolivia Departments
     ]
     humanReadableName: {
       ar: إدارة في بوليفيا
@@ -113,7 +113,7 @@
       cs: Departementy Bolívie
       da: Bolivias departementer
       de: Departamento in Bolivien
-      en: Bolivia departments
+      en: Bolivia Departments
       eo: Departementoj de Bolivio
       es: departamento de Bolivia
       eu: Boliviaren banaketa administratiboa

--- a/sources/cl/chile-regions.hjson
+++ b/sources/cl/chile-regions.hjson
@@ -85,7 +85,7 @@
     }
     name: chile_regions
     legacyIds: [
-      Chile regions
+      Chile Regions
     ]
     humanReadableName: {
       ar: أقليم في تشيلي
@@ -96,7 +96,7 @@
       cs: chilské regiony
       da: Chiles regioner
       de: Region in Chile
-      en: Chile regions
+      en: Chile Regions
       eo: Regionoj de Ĉilio
       es: región de Chile
       eu: Txileko eskualdeak

--- a/sources/co/colombia-departments.hjson
+++ b/sources/co/colombia-departments.hjson
@@ -79,7 +79,7 @@
     }
     name: colombia_departments
     legacyIds: [
-      Colombia departments
+      Colombia Departments
     ]
     humanReadableName: {
       af: Departemente van Colombia

--- a/sources/ec/ecuador-provinces.hjson
+++ b/sources/ec/ecuador-provinces.hjson
@@ -79,7 +79,7 @@
     }
     name: ecuador_province
     legacyIds: [
-      Ecuador province
+      Ecuador Provinces
     ]
     humanReadableName: {
       ar: مقاطعة في الإكوادور
@@ -89,7 +89,7 @@
       cs: Provincie Ekvádoru
       da: Ecuadors provinser
       de: Provinz in Ecuador
-      en: Ecuador provinces
+      en: Ecuador Provinces
       en-ca: Provinces of Ecuador
       en-gb: Provinces of Ecuador
       eo: Provincoj de Ekvadoro

--- a/sources/gy/guyana-regions.hjson
+++ b/sources/gy/guyana-regions.hjson
@@ -71,13 +71,13 @@
     }
     name: guyana_regions
     legacyIds: [
-      Guyana regions
+      Guyana Regions
     ]
     humanReadableName: {
       ar: أقليم في غيانا
       bs: Gvajanske regije
       de: Region Guyanas
-      en: Guyana regions
+      en: Guyana Regions
       es: Organización territorial de Guyana
       fa: مناطق گویان
       he: מחוזות גיאנה

--- a/sources/pe/peru-regions.hjson
+++ b/sources/pe/peru-regions.hjson
@@ -94,14 +94,14 @@
     }
     name: peru_regions
     legacyIds: [
-      Peru regions
+      Peru Regions
     ]
     humanReadableName: {
       ar: أقليم في البيرو
       ast: rexón de Perú
       ca: regió del Perú
       de: Region von Peru
-      en: Peru regions
+      en: Peru Regions
       eo: regiono de Peruo
       es: región de Perú
       eu: Peruko eskualdea

--- a/sources/py/paraguay-departments.hjson
+++ b/sources/py/paraguay-departments.hjson
@@ -91,7 +91,7 @@
     }
     name: paraguay_departments
     legacyIds: [
-      Paraguay departments
+      Paraguay Departments
     ]
     humanReadableName: {
       ar: إدارة في باراغواي
@@ -101,7 +101,7 @@
       cs: Departementy Paraguaye
       de: Departamento in Paraguay
       el: διαμέρισμα της Παραγουάης
-      en: Paraguay departments
+      en: Paraguay Departments
       eo: departemento de Paragvajo
       es: departamento de Paraguay
       eu: Paraguaiko departamendu

--- a/sources/sr/suriname-districts.hjson
+++ b/sources/sr/suriname-districts.hjson
@@ -79,14 +79,14 @@
     }
     name: suriname_districts
     legacyIds: [
-      Suriname districts
+      Suriname Districts
     ]
     humanReadableName: {
       ar: ضاحية في سورينام
       ca: districte del Surinam
       cs: Administrativní dělení Surinamu
       de: Distrikt in Suriname
-      en: Suriname districts
+      en: Suriname Districts
       eo: Distriktoj de Surinamo
       es: distrito de Surinam
       eu: Surinamen banaketa administratiboa

--- a/sources/uy/uruguay-departments.hjson
+++ b/sources/uy/uruguay-departments.hjson
@@ -79,7 +79,7 @@
     }
     name: uruguay_departments
     legacyIds: [
-      Uruguay departments
+      Uruguay Departments
     ]
     humanReadableName: {
       ar: إدارة في الأوروغواي
@@ -91,7 +91,7 @@
       cs: departement Uruguaye
       da: Uruguays departementer
       de: Departamento in Uruguay
-      en: Uruguay departments
+      en: Uruguay Departments
       eo: departemento de Urugvajo
       es: departamento de Uruguay
       eu: Uruguaiko departamendua

--- a/sources/ve/venezuela-states.hjson
+++ b/sources/ve/venezuela-states.hjson
@@ -79,7 +79,7 @@
     }
     name: venezuela_states
     legacyIds: [
-      Venezuela states
+      Venezuela States
     ]
     humanReadableName: {
       af: State van Venezuela
@@ -93,7 +93,7 @@
       cs: Státy Venezuely
       da: Venezuelas delstater
       de: Bundesstaat von Venezuela
-      en: Venezuela states
+      en: Venezuela States
       es: estado de Venezuela
       eu: Venezuelako estatua
       fa: ایالت‌های ونزوئلا


### PR DESCRIPTION
We should match the current precedent of capitalizing the
first letter of the country and subdivision type in the layer label.