### PR TITLE
Fix INSEE code for Rhône department of FR

### DIFF
--- a/data/france_departments_v7.geo.json
+++ b/data/france_departments_v7.geo.json
@@ -1325,7 +1325,7 @@
     "iso_3166_2": "FR-69",
     "label_en": "Rhône",
     "label_fr": "Rhône",
-    "insee": "69D"
+    "insee": "69"
   },
   "id": "Q46130"
 },


### PR DESCRIPTION
Fixes #119 

There was a typo in the [Wikidata entry](https://www.wikidata.org/wiki/Q46130) which caused this error. [Wikidata has since been corrected](https://www.wikidata.org/w/index.php?title=Q46130&diff=941373819&oldid=941373589) and I have confirmed this is correct with the official source at https://www.insee.fr/fr/information/2114819#titre-bloc-26. 

This only affects EMS and Kibana versions 7+. Previous versions of EMS and Kibana were not impacted.