### PR TITLE
EMS v7.6 - remove catalogue manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,6 @@ mkdirp.sync('./dist/catalogue');
 const vectorFiles = new Map();
 
 for (const version of constants.VERSIONS) {
-  mkdirp.sync(path.join('./dist/catalogue', version));
-  mkdirp.sync(path.join('./dist/vector', version));
   const catalogueManifest = generateCatalogueManifest({
     version: version,
     tileHostname: tileManifestHostname,
@@ -56,16 +54,21 @@ for (const version of constants.VERSIONS) {
     // Set key = destination path as it is unique across versions
     vectorFiles.set(file.dest, file.src);
   }
-  fs.writeFileSync(
-    path.join('./dist/catalogue', version, 'manifest'),
-    JSON.stringify(catalogueManifest)
-  );
-  fs.writeFileSync(
-    path.join('./dist/vector', version, 'manifest'),
-    JSON.stringify(vectorManifest)
-  );
+  if (catalogueManifest) {
+    mkdirp.sync(path.join('./dist/catalogue', version));
+    fs.writeFileSync(
+      path.join('./dist/catalogue', version, 'manifest'),
+      JSON.stringify(catalogueManifest)
+    );
+  }
+  if (vectorManifest) {
+    mkdirp.sync(path.join('./dist/vector', version));
+    fs.writeFileSync(
+      path.join('./dist/vector', version, 'manifest'),
+      JSON.stringify(vectorManifest)
+    );
+  }
 }
-
 for (const file of vectorFiles) {
   // file is an array of [dest, src]
   const vector = JSON.parse(fs.readFileSync(file[1]));

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -9,5 +9,5 @@ module.exports = Object.freeze({
   VECTOR_STAGING_HOST: 'vector-staging.maps.elastic.co',
   TILE_PRODUCTION_HOST: 'tiles.maps.elastic.co',
   TILE_STAGING_HOST: 'tiles.maps.elstc.co',
-  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0','v7.2'],
+  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0','v7.2', 'v7.6'],
 });

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -27,10 +27,15 @@ function generateCatalogueManifest(opts) {
     vectorHostname: constants.VECTOR_STAGING_HOST,
     ...opts,
   };
-  if (!semver.valid(semver.coerce(opts.version))) {
+  const version = semver.coerce(opts.version);
+  if (!semver.valid(version)) {
     throw new Error('A valid version parameter must be defined');
   }
-  const tilesManifest = semver.lt(semver.coerce(opts.version), '7.2.0')
+  //Catalogue manifest was removed in 7.6+
+  if (semver.gte(version, '7.6.0')) {
+    return;
+  }
+  const tilesManifest = semver.lt(version, '7.2.0')
     ? { id: 'tiles_v2', version: 'v2' }
     : { id: 'tiles', version: 'v7.2' };
   const manifest = {

--- a/test/manifest-v7.js
+++ b/test/manifest-v7.js
@@ -1,0 +1,637 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+const tap = require('tap').test;
+const { generateCatalogueManifest, generateVectorManifest } = require('../scripts/generate-manifest');
+
+const sources = require('./fixtures/valid-sources/sources.json');
+const duplicateNames = require('./fixtures/valid-sources/duplicateNames.json');
+const weightedSources = require('./fixtures/valid-sources/weighted-sources.json');
+const fieldInfo = require('./fixtures/fieldInfo.json');
+
+const stagingExpected = {
+  'layers': [
+    {
+      'layer_id': 'gondor',
+      'created_at': '1200-02-28T17:13:39.288909',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+          'fr': 'Le Silmarillion',
+        },
+        'url': {
+          'en': 'https://en.wikipedia.org/wiki/The_Silmarillion',
+          'fr': 'https://fr.wikipedia.org/wiki/Le_Silmarillion',
+        },
+      }, {
+        'label': {
+          'en': 'Elastic Maps Service',
+        },
+        'url': {
+          'en': 'https://www.elastic.co/elastic-maps-service',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/gondor_v3.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'de': 'Wikidata-Kennung',
+            'en': 'Wikidata identifier',
+            'zh': '维基数据标识符',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'de': 'name (en)',
+            'en': 'name (en)',
+            'zh': '名称 (en)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Gondor',
+        'Gondor Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Gondor Kingdoms',
+        'de': 'Gondor',
+        'zh': '魔多',
+      },
+    }, {
+      'layer_id': 'rohan',
+      'created_at': '1200-02-28T17:13:39.456456',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/rohan_v2.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': false,
+        },
+        {
+          'type': 'topojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/rohan_v2.topo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+          'meta': {
+            'feature_collection_path': 'regions',
+          },
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'de': 'Wikidata-Kennung',
+            'en': 'Wikidata identifier',
+            'zh': '维基数据标识符',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'de': 'name (en)',
+            'en': 'name (en)',
+            'zh': '名称 (en)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Rohan',
+        'Rohan Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Rohan Kingdoms',
+        'de': 'Rohan',
+        'zh': '洛汗',
+      },
+    }, {
+      'layer_id': 'shire',
+      'created_at': '1532-12-25T18:45:32.389979',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': `https://vector-staging.maps.elastic.co/files/shire_v2.geo.json?elastic_tile_service_tos=agree`,
+          'legacy_default': true,
+        },
+        {
+          'type': 'topojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/shire_v2.topo.json?elastic_tile_service_tos=agree',
+          'legacy_default': false,
+
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'de': 'Wikidata-Kennung',
+            'en': 'Wikidata identifier',
+            'zh': '维基数据标识符',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'de': 'name (en)',
+            'en': 'name (en)',
+            'zh': '名称 (en)',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_ws',
+          'label': {
+            'de': 'name (ws)',
+            'en': 'name (ws)',
+            'zh': '名称 (ws)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Shire',
+        'Shire regions',
+        'Shire Regions',
+      ],
+      'layer_name': {
+        'en': 'Shire regions',
+        'de': 'Auenland',
+        'zh': '夏爾',
+      },
+    },
+  ],
+};
+
+const prodExpected = {
+  'layers': [
+    {
+      'layer_id': 'gondor',
+      'created_at': '1200-02-28T17:13:39.288909',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+          'fr': 'Le Silmarillion',
+        },
+        'url': {
+          'en': 'https://en.wikipedia.org/wiki/The_Silmarillion',
+          'fr': 'https://fr.wikipedia.org/wiki/Le_Silmarillion',
+        },
+      }, {
+        'label': {
+          'en': 'Elastic Maps Service',
+        },
+        'url': {
+          'en': 'https://www.elastic.co/elastic-maps-service',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector.maps.elastic.co/files/gondor_v3.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'de': 'Wikidata-Kennung',
+            'en': 'Wikidata identifier',
+            'zh': '维基数据标识符',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'de': 'name (en)',
+            'en': 'name (en)',
+            'zh': '名称 (en)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Gondor',
+        'Gondor Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Gondor Kingdoms',
+        'de': 'Gondor',
+        'zh': '魔多',
+      },
+    }, {
+      'layer_id': 'rohan',
+      'created_at': '1200-02-28T17:13:39.456456',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector.maps.elastic.co/files/rohan_v2.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': false,
+        },
+        {
+          'type': 'topojson',
+          'url': 'https://vector.maps.elastic.co/files/rohan_v2.topo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+          'meta': {
+            'feature_collection_path': 'regions',
+          },
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'de': 'Wikidata-Kennung',
+            'en': 'Wikidata identifier',
+            'zh': '维基数据标识符',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'de': 'name (en)',
+            'en': 'name (en)',
+            'zh': '名称 (en)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Rohan',
+        'Rohan Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Rohan Kingdoms',
+        'de': 'Rohan',
+        'zh': '洛汗',
+      },
+    },
+  ],
+};
+
+const fieldInfoFallbackExpected = {
+  'layers': [
+    {
+      'layer_id': 'gondor',
+      'created_at': '1200-02-28T17:13:39.288909',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+          'fr': 'Le Silmarillion',
+        },
+        'url': {
+          'en': 'https://en.wikipedia.org/wiki/The_Silmarillion',
+          'fr': 'https://fr.wikipedia.org/wiki/Le_Silmarillion',
+        },
+      }, {
+        'label': {
+          'en': 'Elastic Maps Service',
+        },
+        'url': {
+          'en': 'https://www.elastic.co/elastic-maps-service',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/gondor_v3.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'en': 'Wikidata identifier',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'en': 'Kingdom name (English)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Gondor',
+        'Gondor Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Gondor Kingdoms',
+        'de': 'Gondor',
+        'zh': '魔多',
+      },
+    },
+    {
+      'layer_id': 'rohan',
+      'created_at': '1200-02-28T17:13:39.456456',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/rohan_v2.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': false,
+        },
+        {
+          'type': 'topojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/rohan_v2.topo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+          'meta': {
+            'feature_collection_path': 'regions',
+          },
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'en': 'Wikidata identifier',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'en': 'Kingdom name (English)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Rohan',
+        'Rohan Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Rohan Kingdoms',
+        'de': 'Rohan',
+        'zh': '洛汗',
+      },
+    },
+  ],
+};
+
+const fieldInfoMissingNameExpected = {
+  'layers': [
+    {
+      'layer_id': 'gondor',
+      'created_at': '1200-02-28T17:13:39.288909',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+          'fr': 'Le Silmarillion',
+        },
+        'url': {
+          'en': 'https://en.wikipedia.org/wiki/The_Silmarillion',
+          'fr': 'https://fr.wikipedia.org/wiki/Le_Silmarillion',
+        },
+      }, {
+        'label': {
+          'en': 'Elastic Maps Service',
+        },
+        'url': {
+          'en': 'https://www.elastic.co/elastic-maps-service',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/gondor_v3.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'de': 'Wikidata-Kennung',
+            'en': 'Wikidata identifier',
+            'zh': '维基数据标识符',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'en': 'Kingdom name (English)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Gondor',
+        'Gondor Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Gondor Kingdoms',
+        'de': 'Gondor',
+        'zh': '魔多',
+      },
+    },
+    {
+      'layer_id': 'rohan',
+      'created_at': '1200-02-28T17:13:39.456456',
+      'attribution': [{
+        'label': {
+          'en': 'The Silmarillion',
+        },
+      }],
+      'formats': [
+        {
+          'type': 'geojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/rohan_v2.geo.json?elastic_tile_service_tos=agree',
+          'legacy_default': false,
+        },
+        {
+          'type': 'topojson',
+          'url': 'https://vector-staging.maps.elastic.co/files/rohan_v2.topo.json?elastic_tile_service_tos=agree',
+          'legacy_default': true,
+          'meta': {
+            'feature_collection_path': 'regions',
+          },
+        },
+      ],
+      'fields': [
+        {
+          'type': 'id',
+          'id': 'wikidata',
+          'label': {
+            'de': 'Wikidata-Kennung',
+            'en': 'Wikidata identifier',
+            'zh': '维基数据标识符',
+          },
+        },
+        {
+          'type': 'property',
+          'id': 'label_en',
+          'label': {
+            'en': 'Kingdom name (English)',
+          },
+        },
+      ],
+      'legacy_ids': [
+        'Rohan',
+        'Rohan Kingdoms',
+      ],
+      'layer_name': {
+        'en': 'Rohan Kingdoms',
+        'de': 'Rohan',
+        'zh': '洛汗',
+      },
+    },
+  ],
+};
+
+tap('vector manifest tests v7', t => {
+  const staging = generateVectorManifest(sources, {
+    version: 'v7.2',
+    hostname: 'vector-staging.maps.elastic.co',
+    fieldInfo: fieldInfo,
+  });
+  t.deepEquals(staging, stagingExpected, 'v7.2');
+
+  const prod = generateVectorManifest(sources, {
+    version: 'v7.2',
+    production: true,
+    hostname: 'vector.maps.elastic.co',
+    fieldInfo: fieldInfo,
+  });
+  t.deepEquals(prod, prodExpected, 'production');
+
+  const unsafeDuplicateNames = function () {
+    return generateVectorManifest(duplicateNames, {
+      version: 'v7.2',
+      hostname: 'vector-staging.maps.elastic.co',
+      fieldInfo: fieldInfo,
+    });
+  };
+  t.throws(unsafeDuplicateNames, 'Source names cannot be duplicate in manifests');
+
+  const weightedOrder = generateVectorManifest(weightedSources, {
+    version: 'v7.2',
+  }).layers.map(layer => layer.layer_id);
+  t.deepEquals(weightedOrder, ['rohan', 'gondor', 'mordor_regions', 'shire']);
+
+
+  const fieldInfoFallback = generateVectorManifest(sources, {
+    version: 'v7.2',
+    hostname: 'vector-staging.maps.elastic.co',
+    production: true,
+  });
+  t.deepEquals(fieldInfoFallback, fieldInfoFallbackExpected,
+    'should fallback to source field `desc` if fieldInfos is not available');
+
+  const fieldInfoMissingName = generateVectorManifest(sources, {
+    version: 'v7.2',
+    hostname: 'vector-staging.maps.elastic.co',
+    production: true,
+    fieldInfo: {
+      'wikidata': {
+        'wikidata': 'Q43649390',
+        'i18n': {
+          'de': 'Wikidata-Kennung',
+          'en': 'Wikidata identifier',
+          'zh': '维基数据标识符',
+        },
+      },
+    },
+  });
+  t.deepEquals(fieldInfoMissingName, fieldInfoMissingNameExpected,
+    'should fallback to source field `desc` if `fieldInfo.name.i18n` is not available');
+  t.end();
+
+});
+
+tap('catalogue tests 7.2', t => {
+  const stagingCatalogue = generateCatalogueManifest({
+    version: 'v7.2',
+    tileHostname: 'tiles.maps.elstc.co',
+    vectorHostname: 'vector-staging.maps.elastic.co',
+  });
+  t.deepEquals(stagingCatalogue, {
+    services: [{
+      id: 'tiles',
+      name: 'Elastic Maps Tile Service',
+      manifest: 'https://tiles.maps.elstc.co/v7.2/manifest',
+      type: 'tms',
+    }, {
+      id: 'geo_layers',
+      name: 'Elastic Maps Vector Service',
+      manifest: 'https://vector-staging.maps.elastic.co/v7.2/manifest',
+      type: 'file',
+    }],
+  }, '7.2 staging catalogue should exist');
+
+  const prodCatalogue = generateCatalogueManifest({
+    version: 'v7.2',
+    tileHostname: 'tiles.maps.elastic.co',
+    vectorHostname: 'vector.maps.elastic.co',
+  });
+  t.deepEquals(prodCatalogue, {
+    services: [{
+      id: 'tiles',
+      name: 'Elastic Maps Tile Service',
+      manifest: 'https://tiles.maps.elastic.co/v7.2/manifest',
+      type: 'tms',
+    }, {
+      id: 'geo_layers',
+      name: 'Elastic Maps Vector Service',
+      manifest: 'https://vector.maps.elastic.co/v7.2/manifest',
+      type: 'file',
+    }],
+  }, '7.2 production catalogue should exist');
+  t.end();
+});
+
+tap('catalogue tests >= 7.6', t => {
+  const stagingCatalogue = generateCatalogueManifest({
+    version: 'v7.6',
+    tileHostname: 'tiles.maps.elstc.co',
+    vectorHostname: 'vector-staging.maps.elastic.co',
+  });
+  t.false(stagingCatalogue, '7.6 staging catalogue should not exist');
+
+  const prodCatalogue = generateCatalogueManifest({
+    version: 'v7.6',
+    tileHostname: 'tiles.maps.elastic.co',
+    vectorHostname: 'vector.maps.elastic.co',
+  });
+  t.false(prodCatalogue, '7.6 production catalogue should not exist');
+  t.end();
+});


### PR DESCRIPTION
Fixes #138 

To test this, run `yarn build` and check that the catalogue manifest **does not** get created in the ./dist/v7.6 subdirectory. Also check that the catalogue manifest **does** get created in prior releases (e.g. v2, v6.x, v7.0, v7.2). 