### PR TITLE
Use Node.js LTS docker image for building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ fi
 
 if [[ "$1" != "nodocker" ]]; then
 
-    NODE_IMG="node:8"
+    NODE_IMG="node:lts"
 
     echo "Generating manifests and vector data files for all versions using ${NODE_IMG} docker image"
     docker pull $NODE_IMG


### PR DESCRIPTION
Support for Node.js v8 will reach end of life on 2019-12-31. I propose we use the LTS release for the Node.js docker images going forward.

Alternatively, we could try to keep the Node.js version in sync with Kibana (currently `10`). But I do not see the need and `node:lts` (currently `12`) is perpetually updated.