### PR TITLE
Add EMS version to manifests

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -39,6 +39,7 @@ function generateCatalogueManifest(opts) {
     ? { id: 'tiles_v2', version: 'v2' }
     : { id: 'tiles', version: 'v7.2' };
   const manifest = {
+    version: `${version.major}.${version.minor}`,
     services: [{
       id: tilesManifest.id,
       name: 'Elastic Maps Tile Service',
@@ -108,6 +109,7 @@ function generateVectorManifest(sources, opts) {
   }
 
   const manifest = {
+    version: `${semver.major(manifestVersion)}.${semver.minor(manifestVersion)}`,
     layers: layers,
   };
   return manifest;

--- a/test/manifest-bad.js
+++ b/test/manifest-bad.js
@@ -12,7 +12,7 @@ const sources = require('./fixtures/valid-sources/sources.json');
 tap('Bad manifests', t => {
 
   const noVersion = generateVectorManifest(sources);
-  t.deepEquals(noVersion, { layers: [] }, 'no layers when version 0');
+  t.deepEquals(noVersion, { version: '0.0', layers: [] }, 'no layers when version 0');
 
   t.throws(function () {
     generateVectorManifest(sources, {

--- a/test/manifest-v1.js
+++ b/test/manifest-v1.js
@@ -14,6 +14,7 @@ const weightedSources = require('./fixtures/valid-sources/weighted-sources.json'
 const fieldInfo = require('./fixtures/fieldInfo.json');
 
 const v1Expected = {
+  'version': '1.0',
   'layers': [{
     'attribution': '[The Silmarillion](https://en.wikipedia.org/wiki/The_Silmarillion)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)',
     'weight': 0,
@@ -56,6 +57,7 @@ const v1Expected = {
 };
 
 const prodExpected = {
+  'version': '1.0',
   'layers': [
     {
       'attribution': '[The Silmarillion](https://en.wikipedia.org/wiki/The_Silmarillion)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)',
@@ -81,6 +83,7 @@ const prodExpected = {
 };
 
 const safeDuplicatesExpected = {
+  'version': '1.0',
   'layers': [{
     'attribution': 'The Silmarillion',
     'weight': 0,
@@ -152,6 +155,7 @@ tap('v1 tests', t => {
     vectorHostname: 'vector-staging.maps.elastic.co',
   });
   t.deepEquals(v1Catalogue, {
+    version: '1.0',
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',
@@ -171,6 +175,7 @@ tap('v1 tests', t => {
     vectorHostname: 'vector.maps.elastic.co',
   });
   t.deepEquals(prodCatalogue, {
+    version: '1.0',
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',

--- a/test/manifest-v2.js
+++ b/test/manifest-v2.js
@@ -16,6 +16,7 @@ const badVersions = require('./fixtures/invalid-sources/bad-versions');
 const fieldInfo = require('./fixtures/fieldInfo.json');
 
 const v2Expected = {
+  'version': '2.0',
   'layers': [
     {
       'attribution': '[The Silmarillion](https://en.wikipedia.org/wiki/The_Silmarillion)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)',
@@ -86,6 +87,7 @@ const v2Expected = {
 };
 
 const prodExpected = {
+  'version': '2.0',
   'layers': [
     {
       'attribution': '[The Silmarillion](https://en.wikipedia.org/wiki/The_Silmarillion)|[Elastic Maps Service](https://www.elastic.co/elastic-maps-service)',
@@ -197,6 +199,7 @@ tap('v2 tests', t => {
     vectorHostname: 'vector-staging.maps.elastic.co',
   });
   t.deepEquals(v2Catalogue, {
+    version: '2.0',
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',
@@ -216,6 +219,7 @@ tap('v2 tests', t => {
     vectorHostname: 'vector.maps.elastic.co',
   });
   t.deepEquals(prodCatalogue, {
+    version: '2.0',
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',

--- a/test/manifest-v6.js
+++ b/test/manifest-v6.js
@@ -13,6 +13,7 @@ const weightedSources = require('./fixtures/valid-sources/weighted-sources.json'
 const fieldInfo = require('./fixtures/fieldInfo.json');
 
 const v6Expected = {
+  'version': '6.6',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -187,6 +188,7 @@ const v6Expected = {
 };
 
 const prodExpected = {
+  'version': '6.6',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -301,6 +303,7 @@ const prodExpected = {
 };
 
 const fieldInfoFallbackExpected = {
+  'version': '6.6',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -408,6 +411,7 @@ const fieldInfoFallbackExpected = {
 };
 
 const fieldInfoMissingNameExpected = {
+  'version': '6.6',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -581,6 +585,7 @@ tap('v6 tests', t => {
     vectorHostname: 'vector-staging.maps.elastic.co',
   });
   t.deepEquals(v6Catalogue, {
+    version: '6.6',
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',
@@ -600,6 +605,7 @@ tap('v6 tests', t => {
     vectorHostname: 'vector.maps.elastic.co',
   });
   t.deepEquals(prodCatalogue, {
+    version: '6.6',
     services: [{
       id: 'tiles_v2',
       name: 'Elastic Maps Tile Service',

--- a/test/manifest-v7.2.js
+++ b/test/manifest-v7.2.js
@@ -13,6 +13,7 @@ const weightedSources = require('./fixtures/valid-sources/weighted-sources.json'
 const fieldInfo = require('./fixtures/fieldInfo.json');
 
 const stagingExpected = {
+  'version': '7.2',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -187,6 +188,7 @@ const stagingExpected = {
 };
 
 const prodExpected = {
+  'version': '7.2',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -301,6 +303,7 @@ const prodExpected = {
 };
 
 const fieldInfoFallbackExpected = {
+  'version': '7.2',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -408,6 +411,7 @@ const fieldInfoFallbackExpected = {
 };
 
 const fieldInfoMissingNameExpected = {
+  'version': '7.2',
   'layers': [
     {
       'layer_id': 'gondor',
@@ -585,6 +589,7 @@ tap('catalogue tests <=7.2', t => {
     vectorHostname: 'vector-staging.maps.elastic.co',
   });
   t.deepEquals(stagingCatalogue, {
+    version: '7.2',
     services: [{
       id: 'tiles',
       name: 'Elastic Maps Tile Service',
@@ -604,6 +609,7 @@ tap('catalogue tests <=7.2', t => {
     vectorHostname: 'vector.maps.elastic.co',
   });
   t.deepEquals(prodCatalogue, {
+    version: '7.2',
     services: [{
       id: 'tiles',
       name: 'Elastic Maps Tile Service',

--- a/test/manifest-v7.6.js
+++ b/test/manifest-v7.6.js
@@ -13,182 +13,185 @@ const {
 const sources = require('./fixtures/valid-sources/sources.json');
 const fieldInfo = require('./fixtures/fieldInfo.json');
 
-const vectorExpected = {
-  layers: [
-    {
-      layer_id: 'gondor',
-      created_at: '1200-02-28T17:13:39.288909',
-      attribution: [
-        {
-          label: {
-            en: 'The Silmarillion',
-            fr: 'Le Silmarillion',
+function getExpectedVector(version) {
+  return {
+    version: version,
+    layers: [
+      {
+        layer_id: 'gondor',
+        created_at: '1200-02-28T17:13:39.288909',
+        attribution: [
+          {
+            label: {
+              en: 'The Silmarillion',
+              fr: 'Le Silmarillion',
+            },
+            url: {
+              en: 'https://en.wikipedia.org/wiki/The_Silmarillion',
+              fr: 'https://fr.wikipedia.org/wiki/Le_Silmarillion',
+            },
           },
-          url: {
-            en: 'https://en.wikipedia.org/wiki/The_Silmarillion',
-            fr: 'https://fr.wikipedia.org/wiki/Le_Silmarillion',
+          {
+            label: {
+              en: 'Elastic Maps Service',
+            },
+            url: {
+              en: 'https://www.elastic.co/elastic-maps-service',
+            },
           },
+        ],
+        formats: [
+          {
+            type: 'geojson',
+            url: '/files/gondor_v3.geo.json',
+            legacy_default: true,
+          },
+        ],
+        fields: [
+          {
+            type: 'id',
+            id: 'wikidata',
+            label: {
+              de: 'Wikidata-Kennung',
+              en: 'Wikidata identifier',
+              zh: '维基数据标识符',
+            },
+          },
+          {
+            type: 'property',
+            id: 'label_en',
+            label: {
+              de: 'name (en)',
+              en: 'name (en)',
+              zh: '名称 (en)',
+            },
+          },
+        ],
+        legacy_ids: ['Gondor', 'Gondor Kingdoms'],
+        layer_name: {
+          en: 'Gondor Kingdoms',
+          de: 'Gondor',
+          zh: '魔多',
         },
-        {
-          label: {
-            en: 'Elastic Maps Service',
-          },
-          url: {
-            en: 'https://www.elastic.co/elastic-maps-service',
-          },
-        },
-      ],
-      formats: [
-        {
-          type: 'geojson',
-          url: '/files/gondor_v3.geo.json',
-          legacy_default: true,
-        },
-      ],
-      fields: [
-        {
-          type: 'id',
-          id: 'wikidata',
-          label: {
-            de: 'Wikidata-Kennung',
-            en: 'Wikidata identifier',
-            zh: '维基数据标识符',
-          },
-        },
-        {
-          type: 'property',
-          id: 'label_en',
-          label: {
-            de: 'name (en)',
-            en: 'name (en)',
-            zh: '名称 (en)',
-          },
-        },
-      ],
-      legacy_ids: ['Gondor', 'Gondor Kingdoms'],
-      layer_name: {
-        en: 'Gondor Kingdoms',
-        de: 'Gondor',
-        zh: '魔多',
       },
-    },
-    {
-      layer_id: 'rohan',
-      created_at: '1200-02-28T17:13:39.456456',
-      attribution: [
-        {
-          label: {
-            en: 'The Silmarillion',
+      {
+        layer_id: 'rohan',
+        created_at: '1200-02-28T17:13:39.456456',
+        attribution: [
+          {
+            label: {
+              en: 'The Silmarillion',
+            },
           },
-        },
-      ],
-      formats: [
-        {
-          type: 'geojson',
-          url: '/files/rohan_v2.geo.json',
-          legacy_default: false,
-        },
-        {
-          type: 'topojson',
-          url: '/files/rohan_v2.topo.json',
-          legacy_default: true,
-          meta: {
-            feature_collection_path: 'regions',
+        ],
+        formats: [
+          {
+            type: 'geojson',
+            url: '/files/rohan_v2.geo.json',
+            legacy_default: false,
           },
-        },
-      ],
-      fields: [
-        {
-          type: 'id',
-          id: 'wikidata',
-          label: {
-            de: 'Wikidata-Kennung',
-            en: 'Wikidata identifier',
-            zh: '维基数据标识符',
+          {
+            type: 'topojson',
+            url: '/files/rohan_v2.topo.json',
+            legacy_default: true,
+            meta: {
+              feature_collection_path: 'regions',
+            },
           },
-        },
-        {
-          type: 'property',
-          id: 'label_en',
-          label: {
-            de: 'name (en)',
-            en: 'name (en)',
-            zh: '名称 (en)',
+        ],
+        fields: [
+          {
+            type: 'id',
+            id: 'wikidata',
+            label: {
+              de: 'Wikidata-Kennung',
+              en: 'Wikidata identifier',
+              zh: '维基数据标识符',
+            },
           },
+          {
+            type: 'property',
+            id: 'label_en',
+            label: {
+              de: 'name (en)',
+              en: 'name (en)',
+              zh: '名称 (en)',
+            },
+          },
+        ],
+        legacy_ids: ['Rohan', 'Rohan Kingdoms'],
+        layer_name: {
+          en: 'Rohan Kingdoms',
+          de: 'Rohan',
+          zh: '洛汗',
         },
-      ],
-      legacy_ids: ['Rohan', 'Rohan Kingdoms'],
-      layer_name: {
-        en: 'Rohan Kingdoms',
-        de: 'Rohan',
-        zh: '洛汗',
       },
-    },
-    {
-      layer_id: 'shire',
-      created_at: '1532-12-25T18:45:32.389979',
-      attribution: [
-        {
-          label: {
-            en: 'The Silmarillion',
+      {
+        layer_id: 'shire',
+        created_at: '1532-12-25T18:45:32.389979',
+        attribution: [
+          {
+            label: {
+              en: 'The Silmarillion',
+            },
           },
-        },
-      ],
-      formats: [
-        {
-          type: 'geojson',
-          url: `/files/shire_v2.geo.json`,
-          legacy_default: true,
-        },
-        {
-          type: 'topojson',
-          url: '/files/shire_v2.topo.json',
-          legacy_default: false,
-        },
-      ],
-      fields: [
-        {
-          type: 'id',
-          id: 'wikidata',
-          label: {
-            de: 'Wikidata-Kennung',
-            en: 'Wikidata identifier',
-            zh: '维基数据标识符',
+        ],
+        formats: [
+          {
+            type: 'geojson',
+            url: `/files/shire_v2.geo.json`,
+            legacy_default: true,
           },
-        },
-        {
-          type: 'property',
-          id: 'label_en',
-          label: {
-            de: 'name (en)',
-            en: 'name (en)',
-            zh: '名称 (en)',
+          {
+            type: 'topojson',
+            url: '/files/shire_v2.topo.json',
+            legacy_default: false,
           },
-        },
-        {
-          type: 'property',
-          id: 'label_ws',
-          label: {
-            de: 'name (ws)',
-            en: 'name (ws)',
-            zh: '名称 (ws)',
+        ],
+        fields: [
+          {
+            type: 'id',
+            id: 'wikidata',
+            label: {
+              de: 'Wikidata-Kennung',
+              en: 'Wikidata identifier',
+              zh: '维基数据标识符',
+            },
           },
+          {
+            type: 'property',
+            id: 'label_en',
+            label: {
+              de: 'name (en)',
+              en: 'name (en)',
+              zh: '名称 (en)',
+            },
+          },
+          {
+            type: 'property',
+            id: 'label_ws',
+            label: {
+              de: 'name (ws)',
+              en: 'name (ws)',
+              zh: '名称 (ws)',
+            },
+          },
+        ],
+        legacy_ids: ['Shire', 'Shire regions', 'Shire Regions'],
+        layer_name: {
+          en: 'Shire regions',
+          de: 'Auenland',
+          zh: '夏爾',
         },
-      ],
-      legacy_ids: ['Shire', 'Shire regions', 'Shire Regions'],
-      layer_name: {
-        en: 'Shire regions',
-        de: 'Auenland',
-        zh: '夏爾',
       },
-    },
-  ],
+    ],
+  };
 };
 
 tap('>=7.6 tests', t => {
-  ['v7.6', 'v7.7', 'v7.8','v7.9','v7.10'].forEach(version => {
+  ['7.6', '7.7', '7.8', '7.9', '7.10'].forEach(version => {
     const catalogue = generateCatalogueManifest({
-      version: version,
+      version: `v${version}`,
       tileHostname: 'tiles.maps.elstc.co',
       vectorHostname: 'vector.maps.elastic.co',
     });
@@ -196,23 +199,27 @@ tap('>=7.6 tests', t => {
 
     // It is not necessary to test different hostnames, since URLs in manifest are relative
     const vector = generateVectorManifest(sources, {
-      version: version,
+      version: `v${version}`,
       hostname: 'vector.maps.elastic.co',
       fieldInfo: fieldInfo,
     });
-    t.deepEquals(vector, vectorExpected, 'v7.6 vector manifest');
+    t.deepEquals(vector, getExpectedVector(version), 'v7.6 vector manifest');
   });
   t.end();
 });
 
 //v8 vector manifest should fail - to be removed in EMS v8.0
-tap('Check that v8.0 fails', function (t) {
-  t.throws(function () {
-    generateVectorManifest(sources, {
-      version: 'v8.0',
-      hostname: 'vector.maps.elastic.co',
-      fieldInfo: fieldInfo,
-    });
-  }, new Error('Unable to get a manifest for version 8.0'), 'throws assert error');
+tap('Check that v8.0 fails', function(t) {
+  t.throws(
+    function() {
+      generateVectorManifest(sources, {
+        version: 'v8.0',
+        hostname: 'vector.maps.elastic.co',
+        fieldInfo: fieldInfo,
+      });
+    },
+    new Error('Unable to get a manifest for version 8.0'),
+    'throws assert error'
+  );
   t.end();
 });


### PR DESCRIPTION
Partially fixes #159 

This PR adds a root level `version` property to all catalogue and vector file manifests containing the EMS version in the form of "{major}.{minor}" (e.g. 1.0, 2.0, 6.6, 7.2). 

Since this only adds a new property and does not modify the schema of the manifests otherwise, I believe this is safe to apply retroactively to all EMS versions. I have successfully tested these manifests in Kibana 5.6.14, 6.8.0, 7.1.1, 7.2.1, and the 7.6 branch.