### PR TITLE
Prepare EMS v7.7

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -9,5 +9,5 @@ module.exports = Object.freeze({
   VECTOR_STAGING_HOST: 'vector-staging.maps.elastic.co',
   TILE_PRODUCTION_HOST: 'tiles.maps.elastic.co',
   TILE_STAGING_HOST: 'tiles.maps.elstc.co',
-  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0','v7.2', 'v7.6'],
+  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0','v7.2', 'v7.6', 'v7.7'],
 });


### PR DESCRIPTION
As of 7.6, EMS is matching the latest minor stack release. So we should prepare v7.7 ahead of release.

There are no significant changes from the v7.6 release.