### PR TITLE
Drop support for Node < 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "build": "node index.js"
   },
   "keywords": [],
+  "engines": {
+    "node": ">= 12"
+  },
   "author": "Nick Peihl <nick.peihl@elastic.co>",
   "license": "Elastic-License",
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,6 +1034,11 @@ geojson-rewind@^0.3.1:
     minimist "1.2.0"
     sharkdown "^0.1.0"
 
+geolib@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-3.2.1.tgz#1d7c6e7106eddc10445ba2038550aab63d6e4fa4"
+  integrity sha512-O9nD8iSD4VimupKak8bKySLkkWI5VWetxIXsU7jmJRXxBFRR9LxSXGfTomtcHJLSRiznx+YHXHTOIVq4qgQmPw==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
This is required because the jsts dependency dropped support for Node <12.

Also fixes yarn.lock.