### PR TITLE
Add IT-SD code to Italy Provinces dataset

### DIFF
--- a/data/italy_provinces_v1.geo.json
+++ b/data/italy_provinces_v1.geo.json
@@ -1449,7 +1449,7 @@
   },
   "properties": {
     "istat": "111",
-    "iso_3166_2": "NULL",
+    "iso_3166_2": "IT-SD",
     "label_en": "Province of South Sardinia",
     "label_it": "provincia del Sud Sardegna"
   },


### PR DESCRIPTION
Fixes #189 

South Sardinia ISO code was added to the revision of Italy provinces ([provinces_v2.htjson](https://github.com/elastic/ems-file-service/blob/master/sources/it/provinces_v2.hjson)) that will be available in the next major, but never _backported_ to the older version.

This is just a replacement of the ISO code, without running the full Sophox procedure.