### PR TITLE
Add v7.12 endpoint

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -9,5 +9,5 @@ module.exports = Object.freeze({
   VECTOR_STAGING_HOST: 'vector-staging.maps.elastic.co',
   TILE_PRODUCTION_HOST: 'tiles.maps.elastic.co',
   TILE_STAGING_HOST: 'tiles.maps.elstc.co',
-  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0', 'v7.2', 'v7.6', 'v7.7', 'v7.8', 'v7.9', 'v7.10','v7.11'],
+  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0', 'v7.2', 'v7.6', 'v7.7', 'v7.8', 'v7.9', 'v7.10','v7.11', 'v7.12'],
 });


### PR DESCRIPTION
Part of #202 

This will publish the v7.12 endpoint at https://vector-staging.maps.elastic.co/v7.12/manifest. https://vector.maps.elastic.co/v7.12/manifest will be published at a later date.