### PR TITLE
Release EMS 7.13

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -5,9 +5,26 @@
  */
 
 module.exports = Object.freeze({
-  VECTOR_PRODUCTION_HOST: 'vector.maps.elastic.co',
-  VECTOR_STAGING_HOST: 'vector-staging.maps.elastic.co',
-  TILE_PRODUCTION_HOST: 'tiles.maps.elastic.co',
-  TILE_STAGING_HOST: 'tiles.maps.elstc.co',
-  VERSIONS: ['v1', 'v2', 'v6.6', 'v7.0', 'v7.2', 'v7.6', 'v7.7', 'v7.8', 'v7.9', 'v7.10','v7.11', 'v7.12'],
+  VECTOR_PRODUCTION_HOST: "vector.maps.elastic.co",
+  VECTOR_STAGING_HOST: "vector-staging.maps.elastic.co",
+  TILE_PRODUCTION_HOST: "tiles.maps.elastic.co",
+  TILE_STAGING_HOST: "tiles.maps.elstc.co",
+  VERSIONS: [
+    "v1",
+    "v2",
+    "v6.6",
+    "v7.0",
+    "v7.2",
+    "v7.6",
+    "v7.7",
+    "v7.8",
+    "v7.9",
+    "v7.10",
+    "v7.11",
+    "v7.12",
+    "v7.13",
+    "v7.14",
+    "v7.15",
+    "v7.16",
+  ],
 });


### PR DESCRIPTION
Part of #206.

This PR will set up the Elastic Maps Service release for 7.13. 

Note: This also adds releases up to 7.16 with the caveat that future releases of Elastic Maps Service are in development and may change at any time. 