### PR TITLE
Revert changes to USA States layer in EMS 8.0

### DIFF
--- a/sources/us/states_v1.hjson
+++ b/sources/us/states_v1.hjson
@@ -1,5 +1,5 @@
 {
-    versions: '1 - 7'
+    versions: '1 - 8'
     production: true
     countryCode: US
     type: http

--- a/sources/us/states_v8.hjson
+++ b/sources/us/states_v8.hjson
@@ -1,6 +1,7 @@
 {
-    versions: '>=8'
-    production: true
+    // TODO Layer is disabled until we have proper migrations in kibana
+    versions: '>=9'
+    production: false
     countryCode: US
     type: http
     note:  States of United States


### PR DESCRIPTION
In https://github.com/elastic/ems-file-service/pull/152 we changed the `name` field to `label_en` in the USA States layer in EMS 8+ to match the precedent with other country subdivisions. To make this change transparent to users, we need to have a saved object migration for term joins, styles, and tooltips that use the `name` field.

This PR proposes we delay the changes to the USA States layer to give us more time to implement the saved object migration in Kibana. With a proper migration it should be possible to implement this layer change in a minor EMS release (e.g. 8.1).  In that case we could change the `versions` in the `states_v1.hjson` and `states_v8.hjson` configs to be `1 - 8.0` and `>= 8.1` respectively.