### PR TITLE
Removed copyright char for OSM attribution

### DIFF
--- a/sources/ad/andorra-parishes.hjson
+++ b/sources/ad/andorra-parishes.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ae/emirates.hjson
+++ b/sources/ae/emirates.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/al/albania-counties.hjson
+++ b/sources/al/albania-counties.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ar/argentina-provinces.hjson
+++ b/sources/ar/argentina-provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/at/states.hjson
+++ b/sources/at/states.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/au/states.hjson
+++ b/sources/au/states.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ba/bosnia-herzegovina-territories.hjson
+++ b/sources/ba/bosnia-herzegovina-territories.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/be/provinces.hjson
+++ b/sources/be/provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/be/regions.hjson
+++ b/sources/be/regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/bg/provinces.hjson
+++ b/sources/bg/provinces.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/bh/governorates.hjson
+++ b/sources/bh/governorates.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/bo/bolivia-departments.hjson
+++ b/sources/bo/bolivia-departments.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/br/states.hjson
+++ b/sources/br/states.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/by/regions.hjson
+++ b/sources/by/regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ca/provinces.hjson
+++ b/sources/ca/provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ch/switzerland-cantons.hjson
+++ b/sources/ch/switzerland-cantons.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/cl/chile-regions.hjson
+++ b/sources/cl/chile-regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/cn/provinces.hjson
+++ b/sources/cn/provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/co/colombia-departments.hjson
+++ b/sources/co/colombia-departments.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/cz/czechia-regions.hjson
+++ b/sources/cz/czechia-regions.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/de/states.hjson
+++ b/sources/de/states.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/dk/regions.hjson
+++ b/sources/dk/regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ec/ecuador-provinces.hjson
+++ b/sources/ec/ecuador-provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ee/counties.hjson
+++ b/sources/ee/counties.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/es/autonomous-communities.hjson
+++ b/sources/es/autonomous-communities.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/es/provinces.hjson
+++ b/sources/es/provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/es/provinces_v8.hjson
+++ b/sources/es/provinces_v8.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/fi/regions.hjson
+++ b/sources/fi/regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/fr/departments_v1.hjson
+++ b/sources/fr/departments_v1.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/fr/departments_v7.hjson
+++ b/sources/fr/departments_v7.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/gr/greece-regions.hjson
+++ b/sources/gr/greece-regions.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/gy/guyana-regions.hjson
+++ b/sources/gy/guyana-regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/hr/counties.hjson
+++ b/sources/hr/counties.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/hu/counties.hjson
+++ b/sources/hu/counties.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ie/ireland-counties.hjson
+++ b/sources/ie/ireland-counties.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/in/states.hjson
+++ b/sources/in/states.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/is/iceland_regions.hjson
+++ b/sources/is/iceland_regions.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/it/provinces_v1.hjson
+++ b/sources/it/provinces_v1.hjson
@@ -9,7 +9,7 @@
   attribution: [
     {
       label: {
-        en: © OpenStreetMap contributors
+        en: OpenStreetMap contributors
       }
       url: {
         en: https://www.openstreetmap.org/copyright

--- a/sources/it/provinces_v2.hjson
+++ b/sources/it/provinces_v2.hjson
@@ -9,7 +9,7 @@
   attribution: [
     {
       label: {
-        en: © OpenStreetMap contributors
+        en: OpenStreetMap contributors
       }
       url: {
         en: https://www.openstreetmap.org/copyright

--- a/sources/it/regions.hjson
+++ b/sources/it/regions.hjson
@@ -9,7 +9,7 @@
   attribution: [
     {
       label: {
-        en: © OpenStreetMap contributors
+        en: OpenStreetMap contributors
       }
       url: {
         en: https://www.openstreetmap.org/copyright

--- a/sources/jp/prefectures.hjson
+++ b/sources/jp/prefectures.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/kl/greenland_municipalities.hjson
+++ b/sources/kl/greenland_municipalities.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/kr/south-korea-provinces.hjson
+++ b/sources/kr/south-korea-provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/kw/governorates.hjson
+++ b/sources/kw/governorates.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/li/municipalities.hjson
+++ b/sources/li/municipalities.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/lt/lithuania-counties.hjson
+++ b/sources/lt/lithuania-counties.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/lu/cantons.hjson
+++ b/sources/lu/cantons.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/lv/latvia-territories.hjson
+++ b/sources/lv/latvia-territories.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/md/moldova-districts.hjson
+++ b/sources/md/moldova-districts.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/me/montenegro-municipalities.hjson
+++ b/sources/me/montenegro-municipalities.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/mk/macedonia-municipalities.hjson
+++ b/sources/mk/macedonia-municipalities.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/nl/provinces.hjson
+++ b/sources/nl/provinces.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/no/counties.hjson
+++ b/sources/no/counties.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/om/governorates.hjson
+++ b/sources/om/governorates.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/pe/peru-regions.hjson
+++ b/sources/pe/peru-regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/pl/voivodeships.hjson
+++ b/sources/pl/voivodeships.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/pt/districts.hjson
+++ b/sources/pt/districts.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/py/paraguay-departments.hjson
+++ b/sources/py/paraguay-departments.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/qa/municipalities.hjson
+++ b/sources/qa/municipalities.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ro/romania-counties.hjson
+++ b/sources/ro/romania-counties.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/rs/serbia-districts.hjson
+++ b/sources/rs/serbia-districts.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/sa/provinces.hjson
+++ b/sources/sa/provinces.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/se/counties.hjson
+++ b/sources/se/counties.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/si/municipalities.hjson
+++ b/sources/si/municipalities.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/sk/regions.hjson
+++ b/sources/sk/regions.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/sr/suriname-districts.hjson
+++ b/sources/sr/suriname-districts.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ua/ukraine-regions.hjson
+++ b/sources/ua/ukraine-regions.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/us/states_v1.hjson
+++ b/sources/us/states_v1.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/us/states_v8.hjson
+++ b/sources/us/states_v8.hjson
@@ -10,7 +10,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/uy/uruguay-departments.hjson
+++ b/sources/uy/uruguay-departments.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/ve/venezuela-states.hjson
+++ b/sources/ve/venezuela-states.hjson
@@ -9,7 +9,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/world/admin_regions_lvl2_v1.hjson
+++ b/sources/world/admin_regions_lvl2_v1.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/world/admin_regions_lvl2_v2.hjson
+++ b/sources/world/admin_regions_lvl2_v2.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/sources/world/world_countries_v7.hjson
+++ b/sources/world/world_countries_v7.hjson
@@ -16,7 +16,7 @@
     }
     {
       label: {
-        en: © OpenStreetMap contributors
+        en: OpenStreetMap contributors
       }
       url: {
         en: https://www.openstreetmap.org/copyright

--- a/sources/ye/governorates.hjson
+++ b/sources/ye/governorates.hjson
@@ -16,7 +16,7 @@
       }
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright

--- a/templates/source_template.hjson
+++ b/templates/source_template.hjson
@@ -8,7 +8,7 @@
     attribution: [
       {
         label: {
-          en: © OpenStreetMap contributors
+          en: OpenStreetMap contributors
         }
         url: {
           en: https://www.openstreetmap.org/copyright


### PR DESCRIPTION
Blocked by #234

In order to address https://github.com/elastic/kibana/issues/111982 this PR removes the copyright character from the vector sources so it is the same as our basemaps.