### PR TITLE
Pin the build to Node Fermium releases

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ fi
 
 if [[ "$1" != "nodocker" ]]; then
 
-    NODE_IMG="node:lts"
+    NODE_IMG="node:fermium"
 
     echo "Generating manifests and vector data files for all versions using ${NODE_IMG} docker image"
     docker pull $NODE_IMG


### PR DESCRIPTION
Change the `lts` Docker image by the `fermium` (14.x) image series. We need to update our testing code to keep up with NodeJS.
