### PR TITLE
Upgrade to Node 18

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ fi
 
 if [[ "$1" != "nodocker" ]]; then
 
-    NODE_IMG="node:gallium"
+    NODE_IMG="node:hydrogen"
 
     echo "Generating manifests and vector data files for all versions using ${NODE_IMG} docker image"
     docker pull $NODE_IMG

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "engines": {
-    "node": ">= 12 <= 16"
+    "node": ">= 16 <= 18"
   },
   "author": "Nick Peihl <nick.peihl@elastic.co>",
   "license": "Elastic-License",


### PR DESCRIPTION
Fixes #264

Updates nvm configuration, build script, and `package.json` supported node engines to upgrade to build EMS file service assets with Node 18.
