### PR TITLE
Adding a step to deploy on dev bucket

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -44,7 +44,7 @@ function retry {
 
 
 # Download build from "test" step
-buildkite-agent artifact download "dist.tar.gz" dist --step test
+buildkite-agent artifact download "dist.tar" . --step test
 tar xf dist.tar
 
 if [[ -z "${VECTOR_HOST}" ]]; then
@@ -77,7 +77,7 @@ fi
 
 # Copying files to the cloud
 # Login to the cloud with the service account
-gcloud auth activate-service-account --key-file <(echo "$GCE_ACCOUNT_SECRET")
+gcloud auth activate-service-account --quiet --key-file <(echo "$GCE_ACCOUNT_SECRET")
 unset GCE_ACCOUNT_SECRET
 
 if [[ -n "${ARCHIVE_BUCKET}" ]]; then

--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -43,6 +43,10 @@ function retry {
 }
 
 
+# Download build from "test" step
+buildkite-agent artifact download "dist.tar.gz" dist --step test
+tar xf dist.tar
+
 if [[ -z "${VECTOR_HOST}" ]]; then
     VECTOR_HOST="vector-staging.maps.elastic.co"
     echo "VECTOR_HOST is not set. Defaulting to '${VECTOR_HOST}'."
@@ -75,10 +79,6 @@ fi
 # Login to the cloud with the service account
 gcloud auth activate-service-account --key-file <(echo "$GCE_ACCOUNT_SECRET")
 unset GCE_ACCOUNT_SECRET
-
-# Download build from "test" step
-mkdir -p $PWD/dist
-buildkite-agent artifact download "dist/*" dist --step test
 
 if [[ -n "${ARCHIVE_BUCKET}" ]]; then
     TIMESTAMP=`date +"%Y-%m-%d_%H-%M-%S"`

--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -e
+set +x
+
+# Script to deploy the assets for EMS File Service
+
+# Expected env variables:
+# * [GPROJECT] - Google Cloud project where the buckets live
+# * [GCS_VAULT_SECRET_PATH] -  Path to retrieve the credentials for the google service account (JSON blob)
+# * [TILE_HOST] - "tiles.maps.elastic.co" or "tiles.maps.elstc.co" (default)
+# * [VECTOR_HOST] - "vector.maps.elastic.co" or "vector-staging.maps.elastic.co" (default)
+# * [CATALOGUE_BUCKET] - "elastic-bekitzur-emsfiles-catalogue" or "elastic-bekitzur-emsfiles-catalogue-staging"
+# * [VECTOR_BUCKET] - "elastic-bekitzur-emsfiles-vector" or "elastic-bekitzur-emsfiles-vector-staging".
+#                     If VECTOR_BUCKET or CATALOGUE_BUCKET is not set, the files are built locally but not uploaded.
+# * [ARCHIVE_BUCKET] - "elastic-bekitzur-emsfiles-archive"
+#                      If ARCHIVE_BUCKET is set, a timestamped snapshot of the files is uploaded to the bucket.
+
+function retry {
+    local retries=$1
+    shift
+
+    local count=0
+    until "$@"; do
+        exit=$?
+        wait=$((2 ** count))
+        count=$((count + 1))
+        if [ $count -lt "$retries" ]; then
+            >&2 echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            sleep $wait
+        else
+            >&2 echo "Retry $count/$retries exited $exit, no more retries left."
+            return $exit
+        fi
+    done
+    return 0
+}
+
+
+if [[ -z "${VECTOR_HOST}" ]]; then
+    VECTOR_HOST="vector-staging.maps.elastic.co"
+    echo "VECTOR_HOST is not set. Defaulting to '${VECTOR_HOST}'."
+fi
+
+if [[ -z "${TILE_HOST}" ]]; then
+    TILE_HOST="tiles.maps.elstc.co"
+    echo "TILE_HOST is not set. Defaulting to '${TILE_HOST}'."
+fi
+
+if [[ -z "${CATALOGUE_BUCKET}" || -z "${VECTOR_BUCKET}" ]]; then
+    echo "No data will be uploaded. The following bucket information is not set:"
+    if [[ -z "${VECTOR_BUCKET}" ]]; then
+        echo "VECTOR_BUCKET"
+    fi
+    if [[ -z "${CATALOGUE_BUCKET}" ]]; then
+        echo "CATALOGUE_BUCKET"
+    fi
+fi
+
+export GCE_ACCOUNT_SECRET=$(retry 5 vault read --field=value ${GCS_VAULT_SECRET_PATH})
+unset GCS_VAULT_SECRET_PATH
+
+if [[ -z "${GCE_ACCOUNT_SECRET}" ]]; then
+    echo "GCP credentials not set. Expected google service account JSON blob."
+    exit 1
+fi
+
+# Copying files to the cloud
+# Login to the cloud with the service account
+gcloud auth activate-service-account --key-file <(echo "$GCE_ACCOUNT_SECRET")
+unset GCE_ACCOUNT_SECRET
+
+# Download build from "test" step
+mkdir -p $PWD/dist
+buildkite-agent artifact download "dist/*" dist --step test
+
+if [[ -n "${ARCHIVE_BUCKET}" ]]; then
+    TIMESTAMP=`date +"%Y-%m-%d_%H-%M-%S"`
+    SNAPSHOT_DIR=$PWD/${TIMESTAMP}_snapshot
+    ZIP_FILE=${TIMESTAMP}_${EMS_PROJECT}.tar.gz
+    ZIP_FILE_PATH=$PWD/$ZIP_FILE
+
+    echo "Copying $PWD/dist/* to $SNAPSHOT_DIR"
+    if [[ -d "$SNAPSHOT_DIR" ]]; then
+        echo "$SNAPSHOT_DIR already exist"
+        exit 1
+    fi
+    mkdir -p "$SNAPSHOT_DIR"
+    cp -r $PWD/dist/* "$SNAPSHOT_DIR"
+
+    echo "Archiving bucket into $ZIP_FILE_PATH"
+    tar -czvf "$ZIP_FILE_PATH" -C "$SNAPSHOT_DIR" .
+
+    set +e
+    if gsutil -q stat "gs://$ARCHIVE_BUCKET/$ZIP_FILE" ; then
+        echo ERROR: snapshot file "gs://$ARCHIVE_BUCKET/$ZIP_FILE" already exists 1>&2
+        exit 1
+    fi
+    set -e
+
+    echo "Copying $ZIP_FILE_PATH snapshot to gs://$ARCHIVE_BUCKET"
+    gsutil cp "$ZIP_FILE_PATH" "gs://$ARCHIVE_BUCKET"
+
+    set +e
+    if ! gsutil -q stat "gs://$ARCHIVE_BUCKET/$ZIP_FILE" ; then
+        echo ERROR: snapshot file "gs://$ARCHIVE_BUCKET/$ZIP_FILE" did not upload successfully 1>&2
+        exit 1
+    fi
+fi
+
+# Copy catalogue manifest
+echo "Copying $PWD/dist/catalogue* to gs://$CATALOGUE_BUCKET"
+gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" cp -r -Z $PWD/dist/catalogue/* "gs://$CATALOGUE_BUCKET"
+
+# Copy vector files
+echo "Copying $PWD/dist/vector* to gs://$VECTOR_BUCKET"
+gsutil -m -h "Content-Type:application/json" -h "Cache-Control:public, max-age=3600" cp -r -Z $PWD/dist/vector/* "gs://$VECTOR_BUCKET"
+
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,8 +2,26 @@ agents:
   image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent:latest"
 
 steps:
-  - label: ":hammer_and_wrench: Test and build"
+  - key: test
+    label: ":hammer_and_wrench: Test and build"
     commands: 
       - "yarn install"
       - "yarn test"
-      - "yarn build"
+    artifact_paths: "dist/*"
+
+  - wait:
+      allow_dependency_failure: false
+
+  - key: deploy-dev
+    label: ":rocket: Deploy to dev"
+    # branches: "feature-layers"
+    depends_on: test
+    command: ".buildkite/deploy.sh"
+    env:
+      GPROJECT: "elastic-ems-dev"
+      GCS_VAULT_SECRET_PATH: "secret/ci/elastic-ems-file-service/testing/gcs_acount"
+      TILE_HOST: "tiles.maps.elastic.co"
+      CATALOGUE_BUCKET: "elastic-ems-dev-emsfiles-catalogue-dev"
+      VECTOR_BUCKET: "elastic-ems-dev-emsfiles-vector-dev"
+      VECTOR_HOST: "storage.googleapis.com/elastic-ems-dev-emsfiles-vector-dev"
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,8 @@ steps:
       - "yarn install"
       - "yarn test"
       - "yarn build"
-    artifact_paths: "dist/*"
+      - "tar cf dist.tar dist"
+    artifact_paths: "dist.tar.gz"
 
   - wait:
       allow_dependency_failure: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,7 @@ steps:
     commands: 
       - "yarn install"
       - "yarn test"
+      - "yarn build"
     artifact_paths: "dist/*"
 
   - wait:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
       - "yarn test"
       - "yarn build"
       - "tar cf dist.tar dist"
-    artifact_paths: "dist.tar.gz"
+    artifact_paths: "dist.tar"
 
   - wait:
       allow_dependency_failure: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,19 +11,16 @@ steps:
       - "tar cf dist.tar dist"
     artifact_paths: "dist.tar"
 
-  - wait:
-      allow_dependency_failure: false
-
   - key: deploy-dev
-    label: ":rocket: Deploy to dev"
+    label: ":rocket: Deploy to the development environment"
     # branches: "feature-layers"
     depends_on: test
     command: ".buildkite/deploy.sh"
     env:
-      GPROJECT: "elastic-ems-dev"
       GCS_VAULT_SECRET_PATH: "secret/ci/elastic-ems-file-service/testing/gcs_acount"
       TILE_HOST: "tiles.maps.elastic.co"
+      VECTOR_HOST: "storage.googleapis.com/elastic-ems-dev-emsfiles-vector-dev"
       CATALOGUE_BUCKET: "elastic-ems-dev-emsfiles-catalogue-dev"
       VECTOR_BUCKET: "elastic-ems-dev-emsfiles-vector-dev"
-      VECTOR_HOST: "storage.googleapis.com/elastic-ems-dev-emsfiles-vector-dev"
+      ARCHIVE_BUCKET: "elastic-ems-dev-emsfiles-vector-dev"
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -48,7 +48,7 @@ spec:
     kind: Pipeline
     metadata:
       name: EMS File Service
-      description: Pipeline to run the EMS File Service tests suite
+      description: Pipeline to run the EMS File Service tests suite and deployment
     spec:
       repository: elastic/ems-file-service
       pipeline_file: ".buildkite/pipeline.yml"


### PR DESCRIPTION
**WIP**

Adding new steps on the Buildkite pipeline definition to deploy EMS File Service assets in GCP bucket.

:warning: At this moment this is getting credentials and deploying in the EMS development GCP project. This will be updated with production credentiars and bucket.
