### PR TITLE
Support date versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,13 @@ mkdirp.sync('./dist/catalogue');
 
 const vectorFiles = new Map();
 
-for (const version of constants.VERSIONS) {
+const versions = [
+  ...constants.VERSIONS,
+  ...constants.DATE_VERSIONS.map( el =>  el.date),
+  ...[ constants.LATEST_TAG ]
+]
+
+for (const version of versions) {
   const catalogueManifest = generateCatalogueManifest({
     version: version,
     tileHostname: tileManifestHostname,

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -41,9 +41,9 @@ module.exports = Object.freeze({
   ],
   DATE_VERSIONS: [
     {
-      'date': '2023-10-31',
-      'semver': 'v8.10'
-    }
+      date: "2023-10-31",
+      semver: "v8.10",
+    },
   ],
   LATEST_TAG: "latest",
   GEOJSON_RFC7946: undefined,

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -39,5 +39,12 @@ module.exports = Object.freeze({
     'v8.9',
     'v8.10',
   ],
+  DATE_VERSIONS: [
+    {
+      'date': '2023-10-31',
+      'semver': 'v8.10'
+    }
+  ],
+  LATEST_TAG: "latest",
   GEOJSON_RFC7946: undefined,
 });

--- a/scripts/date-versions.js
+++ b/scripts/date-versions.js
@@ -77,9 +77,7 @@ function coerceToDateSemver(dateVersion) {
  * @returns {String}
  */
 function coerceToSemVer(version) {
-  const isDateVersion =
-    !semver.valid(version) &&
-    (version == constants.LATEST_TAG || checkDateVersion(version));
+  const isDateVersion = !semver.valid(version) && checkDateVersion(version);
 
   // Check the version is in the constants or a valid SemVer
   if (!isDateVersion && !semver.valid(semver.coerce(version))) {

--- a/scripts/date-versions.js
+++ b/scripts/date-versions.js
@@ -4,32 +4,35 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-const semver = require('semver');
-const constants = require('./constants');
+const semver = require("semver");
+const constants = require("./constants");
 
 module.exports = {
   formatDateToIso,
   checkDateVersion,
   coerceToDateSemver,
-  coerceToSemVer
-}
+  coerceToSemVer,
+};
 
 /**
-* Converts a Date instance to the ISO8601
-*
-* @param {Date} date
-* @returns {String}
-*/
-function formatDateToIso (date) {
+ * Converts a Date instance to the ISO8601
+ *
+ * @param {Date} date
+ * @returns {String}
+ */
+function formatDateToIso(date) {
   if (!(date instanceof Date)) {
-    throw new Error('Invalid "date" argument. You must pass a date instance: ' + date.toString())
+    throw new Error(
+      'Invalid "date" argument. You must pass a date instance: ' +
+        date.toString()
+    );
   }
 
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
 
-  return `${year}-${month}-${day}`
+  return `${year}-${month}-${day}`;
 }
 
 /**
@@ -39,21 +42,19 @@ function formatDateToIso (date) {
 * @returns {Boolean}
 */
 function checkDateVersion(version) {
-    if (version === constants.LATEST_TAG){
-      return true;
-    }
+  if (version === constants.LATEST_TAG) {
+    return true;
+  }
 
-    const dateObj = new Date(Date.parse(version));
-    return version === formatDateToIso(dateObj);
+  const dateObj = new Date(Date.parse(version));
+  return version === formatDateToIso(dateObj);
 }
-
 
 /**
  * @typedef {Object} DateSemver
  * @property {String} date - The Date Version
  * @property {String} semver - The Semantic Version
  */
-
 
 /**
  * Returns the assigned Semantic Version of the stack
@@ -62,12 +63,11 @@ function checkDateVersion(version) {
  * @returns {DateSemver}
  */
 function coerceToDateSemver(dateVersion) {
-  if (dateVersion == constants.LATEST_TAG){
+  if (dateVersion == constants.LATEST_TAG) {
     return constants.DATE_VERSIONS.at(-1);
   }
-  return constants.DATE_VERSIONS.find( el => el.date ==dateVersion );
+  return constants.DATE_VERSIONS.find((el) => el.date == dateVersion);
 }
-
 
 /**
  * Converts a version string from a SemVer or Date into the
@@ -76,14 +76,17 @@ function coerceToDateSemver(dateVersion) {
  * @param {String} version
  * @returns {String}
  */
-function coerceToSemVer(version){
-  const isDateVersion = ! semver.valid(version)
-    && ( version == constants.LATEST_TAG || checkDateVersion(version));
+function coerceToSemVer(version) {
+  const isDateVersion =
+    !semver.valid(version) &&
+    (version == constants.LATEST_TAG || checkDateVersion(version));
 
   // Check the version is in the constants or a valid SemVer
   if (!isDateVersion && !semver.valid(semver.coerce(version))) {
-    throw new Error('A valid version parameter must be defined ' + version);
+    throw new Error("A valid version parameter must be defined " + version);
   }
 
-  return semver.coerce(isDateVersion ? coerceToDateSemver(version).semver : version);
+  return semver.coerce(
+    isDateVersion ? coerceToDateSemver(version).semver : version
+  );
 }

--- a/scripts/date-versions.js
+++ b/scripts/date-versions.js
@@ -28,9 +28,9 @@ function formatDateToIso(date) {
     );
   }
 
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
 
   return `${year}-${month}-${day}`;
 }

--- a/scripts/date-versions.js
+++ b/scripts/date-versions.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+const semver = require('semver');
+const constants = require('./constants');
+
+module.exports = {
+  formatDateToIso,
+  checkDateVersion,
+  coerceToDateSemver,
+  coerceToSemVer
+}
+
+/**
+* Converts a Date instance to the ISO8601
+*
+* @param {Date} date
+* @returns {String}
+*/
+function formatDateToIso (date) {
+  if (!(date instanceof Date)) {
+    throw new Error('Invalid "date" argument. You must pass a date instance: ' + date.toString())
+  }
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}
+
+/**
+* Checks a given string is the same after formatting to ISO8601
+
+* @param {String} version
+* @returns {Boolean}
+*/
+function checkDateVersion(version) {
+    if (version === constants.LATEST_TAG){
+      return true;
+    }
+
+    const dateObj = new Date(Date.parse(version));
+    return version === formatDateToIso(dateObj);
+}
+
+
+/**
+ * @typedef {Object} DateSemver
+ * @property {String} date - The Date Version
+ * @property {String} semver - The Semantic Version
+ */
+
+
+/**
+ * Returns the assigned Semantic Version of the stack
+ * for a given date or "latest" tag.
+ * @param {String} dateVersion
+ * @returns {DateSemver}
+ */
+function coerceToDateSemver(dateVersion) {
+  if (dateVersion == constants.LATEST_TAG){
+    return constants.DATE_VERSIONS.at(-1);
+  }
+  return constants.DATE_VERSIONS.find( el => el.date ==dateVersion );
+}
+
+
+/**
+ * Converts a version string from a SemVer or Date into the
+ * equivalent Semantic Version value
+ *
+ * @param {String} version
+ * @returns {String}
+ */
+function coerceToSemVer(version){
+  const isDateVersion = ! semver.valid(version)
+    && ( version == constants.LATEST_TAG || checkDateVersion(version));
+
+  // Check the version is in the constants or a valid SemVer
+  if (!isDateVersion && !semver.valid(semver.coerce(version))) {
+    throw new Error('A valid version parameter must be defined ' + version);
+  }
+
+  return semver.coerce(isDateVersion ? coerceToDateSemver(version).semver : version);
+}

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -8,11 +8,15 @@ const semver = require('semver');
 const _ = require('lodash');
 const { readFileSync } = require('fs');
 const constants = require('./constants');
-const { coerceToSemVer, coerceToDateSemver, checkDateVersion } = require('./date-versions');
+const {
+  coerceToSemVer,
+  coerceToDateSemver,
+  checkDateVersion,
+} = require("./date-versions");
 
 module.exports = {
   generateVectorManifest,
-  generateCatalogueManifest
+  generateCatalogueManifest,
 };
 
 /**
@@ -113,7 +117,7 @@ function generateVectorManifest(sources, opts) {
 
   const manifest = {
     version: isDateVersion
-      ? coerceToDateSemver(opts.version).date
+      ? coerceToDateSemver(opts.version)?.date
       : `${semver.major(manifestVersion)}.${semver.minor(manifestVersion)}`,
     layers: layers,
   };

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -34,6 +34,7 @@ function generateCatalogueManifest(opts) {
     ...opts,
   };
 
+  // Get the Semantic Version (in case it is date based)
   const version = coerceToSemVer(opts.version);
 
   //Catalogue manifest was removed in 7.6+
@@ -81,6 +82,7 @@ function generateVectorManifest(sources, opts) {
 
   const isDateVersion = checkDateVersion(opts.version);
 
+  // Get the Semantic Version (in case it is date based)
   const manifestVersion = coerceToSemVer(opts.version);
   const layers = [];
   const uniqueProperties = [];
@@ -117,7 +119,9 @@ function generateVectorManifest(sources, opts) {
 
   const manifest = {
     version: isDateVersion
+      // Get the Date Version
       ? coerceToDateSemver(opts.version)?.date
+      // Get the Semantic Version
       : `${semver.major(manifestVersion)}.${semver.minor(manifestVersion)}`,
     layers: layers,
   };

--- a/scripts/generate-vectors.js
+++ b/scripts/generate-vectors.js
@@ -7,6 +7,8 @@
 const path = require('path');
 const semver = require('semver');
 
+const { coerceToSemVer } = require('./date-versions');
+
 module.exports = generateVectors;
 
 /**
@@ -27,7 +29,7 @@ function generateVectors(sources, opts) {
     ...opts,
   };
   const files = [];
-  const manifestVersion = semver.coerce(opts.version);
+  const manifestVersion = coerceToSemVer(opts.version);
   for (const source of sources) {
     if ((!opts.production ||
       (opts.production && source.production)) &&

--- a/test/manifest-date.js
+++ b/test/manifest-date.js
@@ -25,16 +25,23 @@ const constants = require("../scripts/constants");
 tap("formatDateToIso", (t) => {
   let validDate = "2023-12-31";
   t.same(
-    validDate,
     formatDateToIso(new Date(validDate)),
+    validDate,
     "Render a valid ISO date"
   );
 
-  let invalidDate = "2023-07-13T14:05:53+0200";
+  let invalidDate = "2023-12-31T23:45:00";
   t.same(
-    "2023-07-13",
     formatDateToIso(new Date(invalidDate)),
-    "Reduce a full timestamp into a date only string"
+    "2023-12-31",
+    "Reduce a timestamp without time zone into a date only string"
+  );
+
+  invalidDate = "2023-12-31T23:45:00-1200";
+  t.same(
+    formatDateToIso(new Date(invalidDate)),
+    "2024-01-01",
+    "Reduce a full timestamp with time zone into a date only string"
   );
 
   t.throws(

--- a/test/manifest-date.js
+++ b/test/manifest-date.js
@@ -30,14 +30,7 @@ tap("formatDateToIso", (t) => {
     "Render a valid ISO date"
   );
 
-  let invalidDate = "2023-12-31T23:45:00";
-  t.same(
-    formatDateToIso(new Date(invalidDate)),
-    "2023-12-31",
-    "Reduce a timestamp without time zone into a date only string"
-  );
-
-  invalidDate = "2023-12-31T23:45:00-1200";
+  let invalidDate = "2023-12-31T23:45:00-1200";
   t.same(
     formatDateToIso(new Date(invalidDate)),
     "2024-01-01",

--- a/test/manifest-date.js
+++ b/test/manifest-date.js
@@ -133,7 +133,7 @@ tap("date based tests", (t) => {
     },
     {},
     { skip: true },
-    "Non existing entry in DATE_VERSIONS sholud throw an error"
+    "Non existing entry in DATE_VERSIONS should throw an error"
   );
   t.end();
 });

--- a/test/manifest-date.js
+++ b/test/manifest-date.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+const tap = require('tap').test;
+const {
+  generateCatalogueManifest,
+  generateVectorManifest,
+} = require('../scripts/generate-manifest');
+
+const { getExpectedVector }= require('./manifest-v7.14');
+
+const {
+  formatDateToIso,
+  checkDateVersion,
+  coerceToDateSemver
+} = require('../scripts/date-versions');
+
+const sources = require('./fixtures/valid-sources/sources.json');
+const fieldInfo = require('./fixtures/fieldInfo.json');
+const constants = require('../scripts/constants');
+
+
+tap('formatDateToIso', t=> {
+
+  let validDate = '2023-12-31';
+  t.same(validDate, formatDateToIso(new Date(validDate)),
+    'Render a valid ISO date');
+
+  let invalidDate = '2023-07-13T14:05:53+0200';
+  t.same('2023-07-13', formatDateToIso(new Date(invalidDate)),
+    'Reduce a full timestamp into a date only string');
+
+  t.throws(function(){ formatDateToIso('foo') },{}, {skip: true},
+    "Random string should throw an error");
+
+  t.throws(function(){ formatDateToIso('2023') },{}, {skip: true},
+    "Single year should throw an error");
+
+  t.throws(function(){ formatDateToIso('2023-10') },{}, {skip: true},
+    "Incomplete date should throw an error");
+
+  t.throws(function(){ formatDateToIso('2023-15-13') },{}, {skip: true},
+    "Invaild date should throw an error");
+
+  t.end();
+});
+
+
+tap('checkDateVersion', t=> {
+  ['2023-01-01', '1955-01-05','2053-05-05'].forEach(version => {
+    t.ok(checkDateVersion(version),
+      `Ensures ${version} is a valid date version`);
+  });
+
+  [
+    '2023',
+    'foo',
+    '2023-01',
+    '2023-13-31',
+    '23-12-31',
+    '2023-07-13T18:28:28+0200'
+  ].forEach( version => {
+    t.notOk(checkDateVersion(version),
+      `Ensures ${version} is not a valid date version`);
+  })
+
+  t.end();
+});
+
+
+tap('date based tests', t => {
+
+  // Get the first key of the DATE_VERSIONS object
+  const validDate = constants.DATE_VERSIONS[0].date;
+
+  // Try to generate a catalogue
+  const catalogue = generateCatalogueManifest({
+    version: validDate,
+    tileHostname: 'tiles.maps.elstc.co',
+    vectorHostname: 'vector.maps.elastic.co',
+  });
+  t.notOk(catalogue, `${validDate} catalogue should be falsy`);
+
+  // Get a manifest
+  const vector = generateVectorManifest(sources, {
+    version: validDate,
+    hostname: 'vector.maps.elastic.co',
+    fieldInfo: fieldInfo,
+    dataDir: 'test/fixtures/data',
+  });
+  t.same(vector, getExpectedVector(validDate), `${validDate} vector manifest`);
+
+  t.throws(function(){
+    generateVectorManifest(sources, {
+      version: '1979-08-26',
+      hostname: 'vector.maps.elastic.co',
+      fieldInfo: fieldInfo,
+      dataDir: 'test/fixtures/data',
+    })
+  },{},
+  {skip: true})
+  t.end();
+});
+
+tap('latest manifest', t => {
+  const version = constants.LATEST_TAG;
+  const dateVersion = coerceToDateSemver(version).date;
+
+  // Try to generate a catalogue
+  const catalogue = generateCatalogueManifest({
+    version: version,
+    tileHostname: 'tiles.maps.elstc.co',
+    vectorHostname: 'vector.maps.elastic.co',
+  });
+  t.notOk(catalogue, `${version} catalogue should be falsy`);
+
+  // Get a manifest
+  const vector = generateVectorManifest(sources, {
+    version: version,
+    hostname: 'vector.maps.elastic.co',
+    fieldInfo: fieldInfo,
+    dataDir: 'test/fixtures/data',
+  });
+  t.same(vector, getExpectedVector(dateVersion), `${version} vector manifest`);
+
+  t.end();
+})
+

--- a/test/manifest-date.js
+++ b/test/manifest-date.js
@@ -4,128 +4,159 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-const tap = require('tap').test;
+const tap = require("tap").test;
 const {
   generateCatalogueManifest,
   generateVectorManifest,
-} = require('../scripts/generate-manifest');
+} = require("../scripts/generate-manifest");
 
-const { getExpectedVector }= require('./manifest-v7.14');
+const { getExpectedVector } = require("./manifest-v7.14");
 
 const {
   formatDateToIso,
   checkDateVersion,
-  coerceToDateSemver
-} = require('../scripts/date-versions');
+  coerceToDateSemver,
+} = require("../scripts/date-versions");
 
-const sources = require('./fixtures/valid-sources/sources.json');
-const fieldInfo = require('./fixtures/fieldInfo.json');
-const constants = require('../scripts/constants');
+const sources = require("./fixtures/valid-sources/sources.json");
+const fieldInfo = require("./fixtures/fieldInfo.json");
+const constants = require("../scripts/constants");
 
+tap("formatDateToIso", (t) => {
+  let validDate = "2023-12-31";
+  t.same(
+    validDate,
+    formatDateToIso(new Date(validDate)),
+    "Render a valid ISO date"
+  );
 
-tap('formatDateToIso', t=> {
+  let invalidDate = "2023-07-13T14:05:53+0200";
+  t.same(
+    "2023-07-13",
+    formatDateToIso(new Date(invalidDate)),
+    "Reduce a full timestamp into a date only string"
+  );
 
-  let validDate = '2023-12-31';
-  t.same(validDate, formatDateToIso(new Date(validDate)),
-    'Render a valid ISO date');
+  t.throws(
+    function () {
+      formatDateToIso("foo");
+    },
+    {},
+    { skip: true },
+    "Random string should throw an error"
+  );
 
-  let invalidDate = '2023-07-13T14:05:53+0200';
-  t.same('2023-07-13', formatDateToIso(new Date(invalidDate)),
-    'Reduce a full timestamp into a date only string');
+  t.throws(
+    function () {
+      formatDateToIso("2023");
+    },
+    {},
+    { skip: true },
+    "Single year should throw an error"
+  );
 
-  t.throws(function(){ formatDateToIso('foo') },{}, {skip: true},
-    "Random string should throw an error");
+  t.throws(
+    function () {
+      formatDateToIso("2023-10");
+    },
+    {},
+    { skip: true },
+    "Incomplete date should throw an error"
+  );
 
-  t.throws(function(){ formatDateToIso('2023') },{}, {skip: true},
-    "Single year should throw an error");
-
-  t.throws(function(){ formatDateToIso('2023-10') },{}, {skip: true},
-    "Incomplete date should throw an error");
-
-  t.throws(function(){ formatDateToIso('2023-15-13') },{}, {skip: true},
-    "Invaild date should throw an error");
+  t.throws(
+    function () {
+      formatDateToIso("2023-15-13");
+    },
+    {},
+    { skip: true },
+    "Invaild date should throw an error"
+  );
 
   t.end();
 });
 
-
-tap('checkDateVersion', t=> {
-  ['2023-01-01', '1955-01-05','2053-05-05'].forEach(version => {
-    t.ok(checkDateVersion(version),
-      `Ensures ${version} is a valid date version`);
+tap("checkDateVersion", (t) => {
+  ["2023-01-01", "1955-01-05", "2053-05-05"].forEach((version) => {
+    t.ok(
+      checkDateVersion(version),
+      `Ensures ${version} is a valid date version`
+    );
   });
 
   [
-    '2023',
-    'foo',
-    '2023-01',
-    '2023-13-31',
-    '23-12-31',
-    '2023-07-13T18:28:28+0200'
-  ].forEach( version => {
-    t.notOk(checkDateVersion(version),
-      `Ensures ${version} is not a valid date version`);
-  })
+    "2023",
+    "foo",
+    "2023-01",
+    "2023-13-31",
+    "23-12-31",
+    "2023-07-13T18:28:28+0200",
+  ].forEach((version) => {
+    t.notOk(
+      checkDateVersion(version),
+      `Ensures ${version} is not a valid date version`
+    );
+  });
 
   t.end();
 });
 
-
-tap('date based tests', t => {
-
+tap("date based tests", (t) => {
   // Get the first key of the DATE_VERSIONS object
   const validDate = constants.DATE_VERSIONS[0].date;
 
   // Try to generate a catalogue
   const catalogue = generateCatalogueManifest({
     version: validDate,
-    tileHostname: 'tiles.maps.elstc.co',
-    vectorHostname: 'vector.maps.elastic.co',
+    tileHostname: "tiles.maps.elstc.co",
+    vectorHostname: "vector.maps.elastic.co",
   });
   t.notOk(catalogue, `${validDate} catalogue should be falsy`);
 
   // Get a manifest
   const vector = generateVectorManifest(sources, {
     version: validDate,
-    hostname: 'vector.maps.elastic.co',
+    hostname: "vector.maps.elastic.co",
     fieldInfo: fieldInfo,
-    dataDir: 'test/fixtures/data',
+    dataDir: "test/fixtures/data",
   });
   t.same(vector, getExpectedVector(validDate), `${validDate} vector manifest`);
 
-  t.throws(function(){
-    generateVectorManifest(sources, {
-      version: '1979-08-26',
-      hostname: 'vector.maps.elastic.co',
-      fieldInfo: fieldInfo,
-      dataDir: 'test/fixtures/data',
-    })
-  },{},
-  {skip: true})
+  t.throws(
+    function () {
+      generateVectorManifest(sources, {
+        version: "1979-08-26",
+        hostname: "vector.maps.elastic.co",
+        fieldInfo: fieldInfo,
+        dataDir: "test/fixtures/data",
+      });
+    },
+    {},
+    { skip: true }
+  );
   t.end();
 });
 
-tap('latest manifest', t => {
+tap("latest manifest", (t) => {
   const version = constants.LATEST_TAG;
   const dateVersion = coerceToDateSemver(version).date;
 
   // Try to generate a catalogue
   const catalogue = generateCatalogueManifest({
     version: version,
-    tileHostname: 'tiles.maps.elstc.co',
-    vectorHostname: 'vector.maps.elastic.co',
+    tileHostname: "tiles.maps.elstc.co",
+    vectorHostname: "vector.maps.elastic.co",
   });
   t.notOk(catalogue, `${version} catalogue should be falsy`);
 
   // Get a manifest
   const vector = generateVectorManifest(sources, {
     version: version,
-    hostname: 'vector.maps.elastic.co',
+    hostname: "vector.maps.elastic.co",
     fieldInfo: fieldInfo,
-    dataDir: 'test/fixtures/data',
+    dataDir: "test/fixtures/data",
   });
   t.same(vector, getExpectedVector(dateVersion), `${version} vector manifest`);
 
   t.end();
-})
-
+});

--- a/test/manifest-date.js
+++ b/test/manifest-date.js
@@ -132,7 +132,8 @@ tap("date based tests", (t) => {
       });
     },
     {},
-    { skip: true }
+    { skip: true },
+    "Non existing entry in DATE_VERSIONS sholud throw an error"
   );
   t.end();
 });
@@ -156,7 +157,11 @@ tap("latest manifest", (t) => {
     fieldInfo: fieldInfo,
     dataDir: "test/fixtures/data",
   });
-  t.same(vector, getExpectedVector(dateVersion), `${version} vector manifest`);
+  t.same(
+    vector,
+    getExpectedVector(dateVersion),
+    `${version} vector manifest should return ${dateVersion}`
+  );
 
   t.end();
 });

--- a/test/manifest-v7.14.js
+++ b/test/manifest-v7.14.js
@@ -13,6 +13,10 @@ const {
 const sources = require('./fixtures/valid-sources/sources.json');
 const fieldInfo = require('./fixtures/fieldInfo.json');
 
+module.exports = {
+  getExpectedVector
+}
+
 function getExpectedVector(version) {
   return {
     version: version,


### PR DESCRIPTION
Resolves #286

This PR introduces support to define release versions tagged as ISO8601 (yyyy-mm-yy). A new array called `DATE_VERSIONS` in the `constants.js` file contains objects as in the block below. This definition provides the minimum changes to how manifests are generated, matching a date release with a Semantic release. Finally, a "latest" folder is also generated with the last entry on the `DATE_VERSIONS` array.


```
  ...
  DATE_VERSIONS: [
    {
      date: "2023-10-31",
      semver: "v8.10",
    },
  ],
  LATEST_TAG: "latest",
  ...
```

