### PR TITLE
Print a simple file with commit hash in the vector distribution root

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -84,7 +84,7 @@ echo "--- :yarn: Build the assets"
 yarn install
 yarn build
 # Print the commit detail into the vector root folder
-sed -e "s@\${EMS_COMMIT}@${BUILDKITE_COMMIT}@g" < templates/index.html.tpl > ./dist/vector/index.html
+sed -e "s@\${EMS_COMMIT}@${BUILDKITE_COMMIT:0:8}@g" < templates/index.html.tpl > ./dist/vector/index.html
 
 
 # Archive the assets if ARCHIVE_BUCKET is set

--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -83,7 +83,8 @@ unset GCE_ACCOUNT_SECRET
 echo "--- :yarn: Build the assets"
 yarn install
 yarn build
-printf "EMS File Service\n%.8s\n" "$(git rev-parse HEAD)" > ./dist/index.html
+# Print the commit detail into the vector root folder
+sed -e "s@\${EMS_COMMIT}@${BUILDKITE_COMMIT}@g" < templates/index.html.tpl > ./dist/vector/index.html
 
 
 # Archive the assets if ARCHIVE_BUCKET is set

--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -63,7 +63,8 @@ if [[ -z "${CATALOGUE_BUCKET}" || -z "${VECTOR_BUCKET}" ]]; then
     exit 1
 fi
 
-export GCE_ACCOUNT_SECRET=$(retry 5 vault read --field=value ${GCS_VAULT_SECRET_PATH})
+export GCE_ACCOUNT_SECRET
+GCE_ACCOUNT_SECRET=$(retry 5 vault read --field=value "${GCS_VAULT_SECRET_PATH}")
 unset GCS_VAULT_SECRET_PATH
 
 if [[ -z "${GCE_ACCOUNT_SECRET}" ]]; then
@@ -82,11 +83,12 @@ unset GCE_ACCOUNT_SECRET
 echo "--- :yarn: Build the assets"
 yarn install
 yarn build
+printf "EMS File Service\n%.8s\n" "$(git rev-parse HEAD)" > ./dist/index.html
 
 
 # Archive the assets if ARCHIVE_BUCKET is set
 if [[ -n "${ARCHIVE_BUCKET}" ]]; then
-    TIMESTAMP=`date +"%Y-%m-%d_%H-%M-%S"`
+    TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
     SNAPSHOT_DIR="./${TIMESTAMP}_snapshot"
     ZIP_FILE=${TIMESTAMP}_emsfiles.tar.gz
     ZIP_FILE_PATH=./$ZIP_FILE

--- a/templates/index.html.tpl
+++ b/templates/index.html.tpl
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>EMS File Service</title>
+</head>
+<body>
+  <h1>EMS File Service</h1>
+  <p>Commit <a href="https://github.com/elastic/ems-file-service/commit/${EMS_COMMIT}">${EMS_COMMIT}</a></p>
+</body>
+</html>


### PR DESCRIPTION
Fixes #276
Fixes #290

Using `sed` and a template to print in `dist/vector/index.html` a minimal doc with the commit identifier of the built distribution.

