### PR TITLE
Add a new version of USA Zip Codes fixing an invalid geometry at zip code 85713

### DIFF
--- a/sources/us/zip_codes_v82.hjson
+++ b/sources/us/zip_codes_v82.hjson
@@ -1,5 +1,5 @@
 {
-  versions: '>=8.2'
+  versions: '>=8.2 <8.13'
   production: true
   type: http
   note: Zip Code Tabulation Areas from the 2018 Census TIGERWEB

--- a/sources/us/zip_codes_v8_13.hjson
+++ b/sources/us/zip_codes_v8_13.hjson
@@ -1,0 +1,91 @@
+{
+  versions: '>=8.13'
+  production: true
+  type: http
+  note: Zip Code Tabulation Areas from the 2018 Census TIGERWEB
+  wikidata: Q136208
+  website: https://www.census.gov/geo/reference/zctas.html
+  data: ftp://ftp2.census.gov/geo/tiger/TIGER2018/ZCTA5/tl_2018_us_zcta510.zip
+  fieldMapping: [
+    {
+      type: id
+      name: zip
+      skipCopy: true
+      desc: 5-digit zip code
+      alias: [
+        zip
+      ]
+    }
+  ]
+  license: Public Domain
+  name: usa_zip_codes
+  legacyIds: [
+    USA Zip Codes
+    USA zip codes
+  ]
+  humanReadableName: {
+    ar: رموز بريد الولايات المتحدة
+    bg: ЗИП код
+    chr: ᎪᏪᎵ ᏧᏪᏓᏍᏗ ᏗᏎᏍᏗ
+    de: ZIP-Code
+    en: USA Zip Codes
+    eo: Poŝtkodoj en Usono
+    es: Código ZIP
+    fr: Code ZIP
+    ga: Cód ZIP
+    gu: ઝીપ કોડ
+    hi: ज़िप कोड
+    hu: ZIP-kód
+    id: Kode ZIP
+    it: codice ZIP
+    ja: ZIPコード
+    kn: ZIP ಸಂಕೇತ
+    ko: ZIP 코드
+    ms: Kod ZIP
+    nl: postcodes in de Verenigde Staten
+    ro: Cod ZIP
+    ru: ZIP-код
+    sco: ZIP Code
+    sh: ZIP kod
+    sr: ЗИП код
+    sv: ZIP-kod
+    ta: சிப் குறியீடு
+    uk: ZIP-код
+    ur: زپ کوڈ
+    vi: Mã bưu điện Hoa Kỳ
+    yi: זיפ קאד
+    zh: 美國郵區編號
+  }
+  emsFormats: [
+  {
+    type: topojson
+    file: usa_zip_codes_v7.topo.json
+    default: true
+    meta: {
+      feature_collection_path: data
+    }
+  },
+  {
+    type: geojson
+    file: usa_zip_codes_v7_1.geo.json
+  }]
+  attribution: [
+    {
+      label: {
+        en: US Census Bureau
+      }
+    }
+    {
+      label: {
+        en: Elastic Maps Service
+      }
+      url: {
+        en: https://www.elastic.co/elastic-maps-service
+      }
+    }
+  ]
+  ttl: 108000
+  weight: 0
+  createdAt: "2019-01-30T22:39:41.210593"
+  id: 1548888012164727
+}


### PR DESCRIPTION
fixes #300

This PR introduces a new version for USA zip codes addressing an error in a self-intersecting geometry for the zip code `87513`.

* A new source is added to leverage this change from 8.13
* A new GeoJSON with the fixed geometries is introduced
* The new source points to the same TopoJSON as the previous version, so this change does not impact Kibana Maps users.

