### PR TITLE
[feature-layers] Update docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20 Docker tag to v0.5 (#336)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.4@sha256:709d4bf1596ca236f0f59fc30ce62a7598b544ed32c11f2869299beded97c471"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.5@sha256:01d63c1c1e9895e410a8b50c0eb0ce8e986c354085a11ed1d00355a12935ac5e"
   cpu: "2"
   memory: "2G"
 
@@ -13,7 +13,7 @@ steps:
     retry:
       automatic: true
     agents:
-      image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.4@sha256:709d4bf1596ca236f0f59fc30ce62a7598b544ed32c11f2869299beded97c471"
+      image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20:0.5@sha256:01d63c1c1e9895e410a8b50c0eb0ce8e986c354085a11ed1d00355a12935ac5e"
       cpu: "4"
       memory: "4G"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `feature-layers`:
 - [Update docker.elastic.co/ci-agent-images/ems/buildkite-agent-node20 Docker tag to v0.5 (#336)](https://github.com/elastic/ems-file-service/pull/336)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)