### PR TITLE
Add support for first 9.x releases

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -45,6 +45,11 @@ export default Object.freeze({
     'v8.15',
     'v8.16',
     'v8.17',
+    'v9.0',
+    'v9.1',
+    'v9.2',
+    'v9.3',
+    'v9.4',
   ],
   DATE_VERSIONS: [
     {

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -101,7 +101,8 @@ function generateVectorManifest(sources, opts) {
           break;
         case 6:
         case 7:
-        case 8: // v6, v7, and v8 manifest schema are the same
+        case 8:
+        case 9: // v6, v7, v8, v9 manifest schema are the same
           uniqueProperties.push('layer_id');
           layers.push(manifestLayerV6(source, opts.hostname, { manifestVersion, fieldInfo: opts.fieldInfo, dataDir: opts.dataDir }));
           break;


### PR DESCRIPTION
Similar to #229 for 8.x, setting up in advance our manifests for the first 9.x releases

