### PR TITLE
[feature-layers] Update dependency @babel/eslint-parser to v7.25.7 (#349)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mapbox/geojson-rewind": "0.5.2",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
-    "@babel/eslint-parser": "7.25.1",
+    "@babel/eslint-parser": "7.25.7",
     "csv-parse": "5.5.6",
     "eslint": "9.11.1",
     "eslint-plugin-babel": "5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^4.0.0"
 
-"@babel/eslint-parser@7.25.1":
-  version "7.25.1"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.25.1.tgz#469cee4bd18a88ff3edbdfbd227bd20e82aa9b82"
-  integrity sha512-Y956ghgTT4j7rKesabkh5WeqgSFZVFwaPR0IWFm7KFHFmmJ4afbG49SmfW4S+GyRPx0Dy5jxEWA5t0rpxfElWg==
+"@babel/eslint-parser@7.25.7":
+  version "7.25.7"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.25.7.tgz#27b43de786c83cbabbcb328efbb4f099ae85415e"
+  integrity sha512-B+BO9x86VYsQHimucBAL1fxTJKF4wyKY6ZVzee9QgzdZOUfs3BaR6AQrgoGrRI+7IFS1wUz/VyQ+SoBcSpdPbw==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `feature-layers`:
 - [Update dependency @babel/eslint-parser to v7.25.7 (#349)](https://github.com/elastic/ems-file-service/pull/349)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)