### PR TITLE
[feature-layers] Update dependency @babel/eslint-parser to v7.25.9 (#359)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mapbox/geojson-rewind": "0.5.2",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
-    "@babel/eslint-parser": "7.25.8",
+    "@babel/eslint-parser": "7.25.9",
     "csv-parse": "5.5.6",
     "eslint": "9.13.0",
     "eslint-plugin-babel": "5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^4.0.0"
 
-"@babel/eslint-parser@7.25.8":
-  version "7.25.8"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.25.8.tgz#0119dec46be547d7a339978dedb9d29e517c2443"
-  integrity sha512-Po3VLMN7fJtv0nsOjBDSbO1J71UhzShE9MuOSkWEV9IZQXzhZklYtzKZ8ZD/Ij3a0JBv1AG3Ny2L3jvAHQVOGg==
+"@babel/eslint-parser@7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz#603c68a63078796527bc9d0833f5e52dd5f9224c"
+  integrity sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `feature-layers`:
 - [Update dependency @babel/eslint-parser to v7.25.9 (#359)](https://github.com/elastic/ems-file-service/pull/359)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)