### PR TITLE
[ci] Configure renovate per branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,6 +3,11 @@
   "repoName": "ems-file-service",
   "targetBranches": ["feature-layers"],
   "targetPRLabels": ["backport"],
+  "branchLabelMapping": {
+    "feature-layers": "feature-layers"
+  },
+  "autoMerge": false,
+  "autoMergeMethod": "squash",
   "commitConflicts": true,
   "fork": false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,9 @@
   "minimumReleaseAge": "14 days",
   "extends": [
     "github>elastic/renovate-config"
+  ],
+  "baseBranches": ["master", "feature-layers"],
+  "labels": [
+    "dependencies"
   ]
 }


### PR DESCRIPTION
This PR configures Renovate and Backport to work with multiple branches in the repository.

## Changes

### Renovate Configuration
- Adds `baseBranches` configuration to track both `master` and `feature-layers` branches
- Adds `dependencies` label to PRs created by Renovate

### Backport Configuration
- Adds `branchLabelMapping` to map the `feature-layers` label to the `feature-layers` branch
- Disables auto-merge by default (`autoMerge: false`)
- Sets auto-merge method to `squash` when enabled

These changes enable Renovate to keep both branches up to date with dependency updates and improve the backport workflow for the `feature-layers` branch.