### PR TITLE
fix(ci): allow maintainers to trigger Buildkite builds

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -8,6 +8,7 @@
             "allow_org_users": true,
             "allowed_repo_permissions": [
                 "admin",
+                "maintain",
                 "write"
             ],
             "allowed_list": [


### PR DESCRIPTION
## Summary

- Adds `maintain` to `allowed_repo_permissions` in `.buildkite/pull-requests.json`
- GitHub's permission model has 5 levels: `read`, `triage`, `write`, `maintain`, `admin` — maintainers hold `maintain`, not `write`
- Without this, maintainers can't trigger PR builds via commit or comment

## Test plan

- [ ] Maintainer comments `buildkite test this` on a PR → build triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)