### PR TITLE
chore(ci): bump buildkite agent image to latest

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node24:1771594567@sha256:7df2fec0e6b90a6d61e83456694de455a544ccd4f4240731d35bbfd9f47b2ea4"
+  image: "docker.elastic.co/ci-agent-images/ems/buildkite-agent-node24:1783438567@sha256:24f8a6deec508b11e4e0748df2af4439f888d9d616eabd3beb0891b9184c8edf"
   cpu: "2"
   memory: "2G"
 


### PR DESCRIPTION
## Summary
- Bump `buildkite-agent-node24` CI image to latest tag/digest (1783438567)

## Test plan
- [ ] CI pipeline runs green on this branch with the new agent image