### PR TITLE
chore(deps): force ip-address to ^10.3.1 (dependabot #250)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "**/minimatch": "^10.2.3",
     "**/diff": "^9.0.0",
     "**/fast-uri": "^4.0.0",
-    "**/brace-expansion": "^5.0.8"
+    "**/brace-expansion": "^5.0.8",
+    "**/ip-address": "^10.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,13 +1985,10 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
-ip-address@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
-  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
-  dependencies:
-    jsbn "1.1.0"
-    sprintf-js "^1.1.3"
+ip-address@^10.3.1, ip-address@^9.0.5:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.4.0.tgz#c5910bc541b6eae287765d1e4846be0308a05d93"
+  integrity sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==
 
 is-actual-promise@^1.0.1:
   version "1.0.2"
@@ -2255,11 +2252,6 @@ jackspeak@^4.2.3:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
-jsbn@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
-  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -3279,11 +3271,6 @@ split@~0.2.10:
   integrity sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==
   dependencies:
     through "2"
-
-sprintf-js@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
-  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 ssri@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
Fixes dependabot alert #250.

## Advisory
- GHSA-mwp4-54f8-5fhr / CVE-2026-69192 (high)
- `ip-address`'s `Address4` decodes leading-zero octets (e.g. `012.0.0.1`) as decimal, while the WHATWG URL host parser, `inet_aton`, and `getaddrinfo` decode the same string as octal. The mismatch lets an attacker craft a host string that this library resolves to one address while the OS/network stack resolves to another, enabling SSRF / trust-boundary bypass.
- Fixed upstream in `ip-address@10.3.1`.

## Chain
`ip-address` is a transitive, dev-only dependency:

```
tap -> ... -> @npmcli/agent -> socks-proxy-agent -> socks@2.8.4 -> ip-address@9.0.5
```

`socks@2.8.4` still declares `ip-address@^9.0.5`, so a plain `yarn upgrade` won't move it. Added a `resolutions` override (same pattern already used for `glob`, `minimatch`, `diff`, `fast-uri`, `brace-expansion`) to force `ip-address` to the patched line.

## Verification
- `yarn install` — lockfile collapses to a single `ip-address@10.4.0` entry, no duplicate versions.
- `require('ip-address')` / `require('socks')` load fine post-bump (same `dist/ip-address.js` entrypoint, no API change relevant to `socks`'s usage).
- `yarn test` — 728 total, 723 pass, 5 skip, 0 fail.

Security link: https://github.com/elastic/ems-file-service/security/dependabot/250