### PR TITLE
ci(backport): add explicit job permissions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,6 +9,10 @@ jobs:
     name: Backport PR
     if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@8a6c0381851f43f9f1fddc7303f0e9015eb57b62 # v12.0.4


### PR DESCRIPTION
## Problem

`.github/workflows/backport.yml` has no `permissions:` block. This repo's default workflow token permissions are set to **read** (`gh api repos/elastic/ems-file-service/actions/permissions/workflow` → `"default_workflow_permissions":"read"`), so `GITHUB_TOKEN` in this job is read-only unless a workflow/job grants more.

`sorenlouv/backport-github-action` needs write access to:
- push the backport branch (`contents: write`)
- open the backport PR (`pull-requests: write`)
- post the status comment on the source PR when there's a merge conflict (`issues: write` -- PR conversation comments go through the issues API)

Without an explicit grant, every backport attempt fails once the action tries to write (push/PR-create/comment), regardless of the `github_token` input being wired up.

## Fix

Add a job-scoped `permissions:` block (least-privilege — scoped to the `backport` job only, not the whole workflow):

```yaml
permissions:
  contents: write
  pull-requests: write
  issues: write
```

## Verification
- YAML parses cleanly (`yaml.safe_load`).
- No functional/behavioral change to the action's inputs — this only grants the token scopes the action already needs to do its documented job (push branch, open PR, comment).