### PR TITLE
chore(ci): parallelize tap test files to speed up CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint --fix *.js scripts/*.js",
-    "test": "tap --timeout=0 test/*.js",
+    "test": "tap --timeout=0 --jobs 4 test/*.js",
     "build": "node index.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary

- Adds `--jobs 4` to the tap test command as a baseline measurement
- Follow-up commit will split `test/source.js` into `source-world.js` and `source-us.js` to allow the slow geometry validation tests to run in parallel

## Test plan

- [ ] Measure CI wall-clock time on this commit (baseline: `--jobs 4` with single `source.js`)
- [ ] Measure CI wall-clock time after file split commit
- [ ] Compare: expected ~100s → ~40s improvement for test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)